### PR TITLE
add version to to cluster status

### DIFF
--- a/kqueen/blueprints/test_api.py
+++ b/kqueen/blueprints/test_api.py
@@ -42,3 +42,11 @@ class TestClusterStatus:
 
         response = client.get(url_for('api.cluster_status', cluster_id=cluster_id))
         assert response.status_code == 200
+
+        rj = response.json
+        print(rj)
+
+        assert 'nodes' in rj
+        assert 'version' in rj
+        assert 'git_version' in rj['version']
+        assert 'platform' in rj['version']

--- a/kqueen/kubeapi.py
+++ b/kqueen/kubeapi.py
@@ -23,8 +23,12 @@ class KubernetesAPI:
         print(self.kubeconfig_file)
 
         # set apis
+        api_client = config.new_client_from_config(config_file=self.kubeconfig_file)
         self.api_corev1 = client.CoreV1Api(
-            api_client=config.new_client_from_config(config_file=self.kubeconfig_file)
+            api_client=api_client,
+        )
+        self.api_version = client.VersionApi(
+            api_client=api_client,
         )
 
     def get_kubeconfig_file(self):
@@ -36,6 +40,9 @@ class KubernetesAPI:
         f.close()
 
         return configfile
+
+    def get_version(self):
+        return self.api_version.get_code().to_dict()
 
     def list_nodes(self):
         out = []

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -23,7 +23,8 @@ class Cluster(Model):
         kubernetes = KubernetesAPI(cluster=self)
 
         out = {
-            'nodes': kubernetes.list_nodes()
+            'nodes': kubernetes.list_nodes(),
+            'version': kubernetes.get_version(),
         }
 
         return out

--- a/kqueen/test_kubeapi.py
+++ b/kqueen/test_kubeapi.py
@@ -21,3 +21,13 @@ class TestKubeApi:
         api = KubernetesAPI(cluster=cluster)
 
         assert hasattr(api, 'cluster')
+
+    def test_version(self, cluster):
+        api = KubernetesAPI(cluster=cluster)
+
+        version = api.get_version()
+        print(version)
+
+        assert isinstance(version, dict)
+        assert 'git_version' in version
+        assert 'platform' in version


### PR DESCRIPTION
It adds more information to cluster status:

```
{
  "nodes": [], 
  "version": {
    "build_date": "2017-09-28T22:46:41Z", 
    "compiler": "gc", 
    "git_commit": "6e937839ac04a38cac63e6a7a306c5d035fe7b0a", 
    "git_tree_state": "clean", 
    "git_version": "v1.8.0", 
    "go_version": "go1.8.3", 
    "major": "1", 
    "minor": "8", 
    "platform": "linux/amd64"
  }
}
```