### PR TITLE
load kubeconfig_remote file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ ENV/
 # NPM asset dir
 node_modules/
 
-# DO NOT COMMIT LOCAL CONFIG
+# Local configuration
 kqueen/config/local.py
+
+# Remote kubeconfig
+kubeconfig_remote
 

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,8 @@ Development
 
 -  Clean etcd storage and prepare examples
 
+`devenv.py` will create few objects to provides basic developer environment. It will also try to download `kubeconfig` file for real cluster but it requires access to Mirantis VPN. However, it can be workarounded by creating file `kubeconfig_remote` in repository root and this file will be used instead of downloading it.
+
 ::
 
     etcdctl rm --recursive /kqueen

--- a/devenv.py
+++ b/devenv.py
@@ -8,6 +8,7 @@ from kqueen.models import User
 
 import requests
 import yaml
+import os
 
 uuid_organization = '22d8df64-4ac9-4be0-89a7-c45ea0fc85da'
 
@@ -19,6 +20,7 @@ uuid_provisioner_local = '203c50d6-3d09-4789-8b8b-1ecb00814436'
 uuid_provisioner_kubespray = '689de9a2-50e0-4fcd-b6a6-96930b5fadc9'
 
 kubeconfig_url = 'https://ci.mcp.mirantis.net/job/deploy-aws-k8s_ha_calico_sm/33/artifact/kubeconfig'
+kubeconfig_file = 'kubeconfig_remote'
 
 app = create_app()
 with app.app_context():
@@ -63,13 +65,21 @@ with app.app_context():
 
 
     try:
+        # load kubeconfig file
+        if os.path.isfile(kubeconfig_file):
+            print('Loading remote kubeconfig from {}'.format(kubeconfig_file))
+            kubeconfig = yaml.load(open(kubeconfig_file).read())
+        else:
+            print('Loading remote kubeconfig from {}'.format(kubeconfig_url))
+            kubeconfig = yaml.load(requests.get(kubeconfig_url).text)
+
         cluster = Cluster(
             user.namespace,
             id=uuid_jenkins,
             name='AWS Calico SM 33',
             state='OK',
             provisioner=provisioner,
-            kubeconfig=yaml.load(requests.get(kubeconfig_url).text),
+            kubeconfig=kubeconfig,
         )
         cluster.save()
     except:


### PR DESCRIPTION
This PR adds way to insert remote cluster from file.

It will try to load file `kubernetes_remote` and Jenkins artifacts are used only if this file isn't found.