### PR TITLE
Allow setting value by args

### DIFF
--- a/kqueen/storages/etcd.py
+++ b/kqueen/storages/etcd.py
@@ -30,14 +30,21 @@ class Field:
     def __init__(self, *args, **kwargs):
         """Initialize Field object
 
+        Argss:
+            value: Set field value. This has higher priority than using attributes.
+
         Attributes:
             required (bool): Set field to be required before saving the model. Defaults to False.
+            value: Set field value.
 
         """
 
-        # TODO: pass value via args[0]
+        # value can be passed as args[0] or kwargs['value']
+        if len(args) >= 1:
+            self.value = args[0]
+        else:
+            self.value = kwargs.get('value', None)
 
-        self.value = kwargs.get('value', None)
         self.required = kwargs.get('required', False)
 
     def set_value(self, value, **kwargs):

--- a/kqueen/storages/test_model_fields.py
+++ b/kqueen/storages/test_model_fields.py
@@ -1,5 +1,6 @@
 from kqueen.storages.etcd import BoolField
 from kqueen.storages.etcd import DatetimeField
+from kqueen.storages.etcd import Field
 from kqueen.storages.etcd import IdField
 from kqueen.storages.etcd import JSONField
 from kqueen.storages.etcd import Model
@@ -230,6 +231,26 @@ class TestDuplicateId:
         print(obj2.get_dict())
 
         assert obj1.id != obj2.id
+
+
+class TestFieldSetValues:
+    def setup(self):
+        self.value = 'abc123'
+
+    def test_create_by_args(self):
+        field = Field(self.value)
+
+        assert field.value == self.value
+
+    def test_create_by_kwargs(self):
+        field = Field(value=self.value)
+
+        assert field.value == self.value
+
+    def test_create_by_both(self):
+        field = Field('args_value', value='kwargs_value')
+
+        assert field.value == 'args_value'
 
 #
 # Relation Field


### PR DESCRIPTION
We now support 3 ways of setting field value:

1. Field('value')
2. Field(value='value')
3. f = Field(); f.set_value('value')