### PR TITLE
Cluster provisioning state API endpoint

### DIFF
--- a/kqueen/blueprints/api/test_cluster.py
+++ b/kqueen/blueprints/api/test_cluster.py
@@ -83,7 +83,8 @@ class TestClusterCRUD(BaseTestCRUD):
     ])
     @pytest.mark.parametrize('url', [
         'cluster_status',
-        'cluster_kubeconfig'
+        'cluster_kubeconfig',
+        'cluster_progress'
     ])
     def test_cluster_status_404(self, url, cluster_id, status_code):
         url = url_for('api.{}'.format(url), pk=cluster_id)
@@ -107,6 +108,17 @@ class TestClusterCRUD(BaseTestCRUD):
         assert 'items' in response.json
         assert 'kinds' in response.json
         assert 'relations' in response.json
+
+    def test_progress_format(self):
+
+        url = url_for('api.cluster_progress', pk=self.obj.id)
+        response = self.client.get(url, headers=self.auth_header)
+
+        assert isinstance(response.json, dict)
+
+        assert 'response' in response.json
+        assert 'progress' in response.json
+        assert 'result' in response.json
 
     def test_create(self, provisioner, user):
         provisioner.save()

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -156,6 +156,27 @@ def cluster_kubeconfig(pk):
     return jsonify(obj.kubeconfig)
 
 
+@api.route('/clusters/<uuid:pk>/progress', methods=['GET'])
+@jwt_required()
+def cluster_progress(pk):
+    obj = get_object(Cluster, pk, current_identity)
+    try:
+        progress = obj.engine.get_progress()
+    except NotImplementedError:
+        progress = {
+            'response': 501,
+            'progress': 0,
+            'result': obj.get_state()
+        }
+    except Exception:
+        progress = {
+            'response': 500,
+            'progress': 0,
+            'result': config.get('CLUSTER_UNKNOWN_STATE')
+        }
+    return jsonify(progress)
+
+
 # Provisioners
 class ListProvisioners(ListView):
     object_class = Provisioner

--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -241,16 +241,3 @@ class AksEngine(BaseEngine):
         # TODO: it does, add list of clusters
 
         return []
-
-    def get_progress(self):
-        """
-        AKS engine don't report any progress.
-
-        Implementation of :func:`~kqueen.engines.base.BaseEngine.get_progress`
-        """
-
-        return {
-            'response': 0,
-            'progress': 100,
-            'result': config.get('CLUSTER_OK_STATE'),
-        }

--- a/kqueen/engines/base.py
+++ b/kqueen/engines/base.py
@@ -169,7 +169,7 @@ class BaseEngine:
             dict: Dictionary representation of the provisioning provress.::
 
                 {
-                    'response': response, # (int) any number other than 0 means failure to determine progress
+                    'response': response, # (int) any number other than 200 means failure to determine progress
                     'progress': progress, # (int) provisioning progress in percents
                     'result': result      # (str) current state of the cluster, i.e. 'Deploying'
                 }

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -220,20 +220,6 @@ class GceEngine(BaseEngine):
 
         return []
 
-    def get_progress(self):
-        """
-        GCE engine don't report any progress because cluster is already provisioned before
-        cluster is imported
-
-        Implementation of :func:`~kqueen.engines.base.BaseEngine.get_progress`
-        """
-
-        return {
-            'response': 0,
-            'progress': 100,
-            'result': config.get('CLUSTER_OK_STATE'),
-        }
-
     @classmethod
     def engine_status(cls):
         test_url = 'https://container.googleapis.com/v1/projects/project/zones/zone/clusters?alt=json'

--- a/kqueen/engines/jenkins.py
+++ b/kqueen/engines/jenkins.py
@@ -274,7 +274,7 @@ class JenkinsEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.get_progress`
         """
-        response = 0
+        response = 200
         progress = 1
         result = config.get('CLUSTER_UNKNOWN_STATE')
         try:
@@ -293,5 +293,5 @@ class JenkinsEngine(BaseEngine):
             else:
                 progress = 100
         except Exception:
-            response = 1
+            response = 500
         return {'response': response, 'progress': progress, 'result': result}


### PR DESCRIPTION
Endpoint for getting status of cluster provisioning, returns result of `get_progress` method on relevant Engine object.