### PR TITLE
GCE should explain project ID not project

### DIFF
--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -45,7 +45,7 @@ class GceEngine(BaseEngine):
             },
             'project': {
                 'type': 'text',
-                'label': 'Project',
+                'label': 'Project ID',
                 'validators': {
                     'required': True,
                 }


### PR DESCRIPTION
Google provisioner should explain that project ID is needed and
not project name.

Closes-bug: #190