### PR TITLE
Configurable timeout for Provisioner

### DIFF
--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -39,6 +39,7 @@ class BaseConfig:
 
     PROVISIONER_ENGINE_WHITELIST = None
 
+    PROVISIONER_TIMEOUT = 1
     PROMETHEUS_WHITELIST = '127.0.0.0/8'
 
     @classmethod

--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -39,7 +39,8 @@ class BaseConfig:
 
     PROVISIONER_ENGINE_WHITELIST = None
 
-    PROVISIONER_TIMEOUT = 1
+    # Timeout for cluster operations (in seconds)
+    PROVISIONER_TIMEOUT = 3600
     PROMETHEUS_WHITELIST = '127.0.0.0/8'
 
     @classmethod

--- a/kqueen/conftest.py
+++ b/kqueen/conftest.py
@@ -58,7 +58,7 @@ def cluster():
         'provisioner': prov,
         'state': 'deployed',
         'kubeconfig': yaml.load(open('kubeconfig_localhost', 'r').read()),
-        'created_at': datetime.datetime(2017, 11, 15, 13, 36, 24),
+        'created_at': datetime.datetime.utcnow().replace(microsecond=0),
         'owner': _user
     }
 

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -53,7 +53,7 @@ class Cluster(Model, metaclass=ModelMeta):
             self.save()
 
         # check for stale clusters
-        max_age = timedelta(hours=config.get('PROVISIONER_TIMEOUT'))
+        max_age = timedelta(seconds=config.get('PROVISIONER_TIMEOUT'))
         if self.state == config.get('CLUSTER_PROVISIONING_STATE') and datetime.utcnow() - self.created_at > max_age:
             self.state = config.get('CLUSTER_ERROR_STATE')
 

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -49,8 +49,9 @@ class Cluster(Model, metaclass=ModelMeta):
             self.state = cluster['state']
             self.save()
 
+        # check for stale clusters
         max_age = timedelta(hours=config.get('PROVISIONER_TIMEOUT'))
-        if datetime.utcnow() - self.created_at > max_age:
+        if self.state == config.get('CLUSTER_PROVISIONING_STATE') and datetime.utcnow() - self.created_at > max_age:
             self.state = config.get('CLUSTER_ERROR_STATE')
 
         return self.state

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -50,7 +50,7 @@ class Cluster(Model, metaclass=ModelMeta):
             self.save()
 
         max_age = timedelta(hours=config.get('PROVISIONER_TIMEOUT'))
-        if datetime.now() - self.created_at > max_age:
+        if datetime.utcnow() - self.created_at > max_age:
             self.state = config.get('CLUSTER_ERROR_STATE')
 
         return self.state

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -11,6 +11,7 @@ from kqueen.storages.etcd import PasswordField
 from kqueen.storages.etcd import RelationField
 from kqueen.storages.etcd import StringField
 from tempfile import mkstemp
+from datetime import datetime, timedelta
 
 import logging
 import os
@@ -47,6 +48,10 @@ class Cluster(Model, metaclass=ModelMeta):
                 return self.state
             self.state = cluster['state']
             self.save()
+
+        max_age = timedelta(hours=config.get('PROVISIONER_TIMEOUT'))
+        if datetime.now() - self.created_at > max_age:
+            self.state = config.get('CLUSTER_ERROR_STATE')
 
         return self.state
 

--- a/kqueen/tests/test_manual_cluster.py
+++ b/kqueen/tests/test_manual_cluster.py
@@ -59,7 +59,7 @@ class TestInsertManualCluster:
             'provisioner': 'Provisioner:{}'.format(self.provisioner_id),
             'kubeconfig': yaml.load(open('kubeconfig_localhost', 'r').read()),
             'owner': 'User:{}'.format(self.user.id),
-            'created_at': datetime.utcnow(),
+            'created_at': str(datetime.utcnow()),
         }
 
         response = self.client.post(

--- a/kqueen/tests/test_manual_cluster.py
+++ b/kqueen/tests/test_manual_cluster.py
@@ -1,6 +1,7 @@
 from flask import url_for
 from kqueen.conftest import auth_header
 from kqueen.models import User
+from datetime import datetime
 
 import json
 import pytest
@@ -58,6 +59,7 @@ class TestInsertManualCluster:
             'provisioner': 'Provisioner:{}'.format(self.provisioner_id),
             'kubeconfig': yaml.load(open('kubeconfig_localhost', 'r').read()),
             'owner': 'User:{}'.format(self.user.id),
+            'created_at': datetime.utcnow(),
         }
 
         response = self.client.post(


### PR DESCRIPTION
This allows to configure timeout during cluster provisioning in case
of unknown errors or network disconnection. By default is it si set
on 1 hour.

Closes: #192
Refs: #162