### PR TITLE
Scaling of cluster nodes

### DIFF
--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -179,6 +179,26 @@ def cluster_progress(pk):
     return jsonify(progress)
 
 
+@api.route('/clusters/<uuid:pk>/resize', methods=['PATCH'])
+@jwt_required()
+def cluster_resize(pk):
+    obj = get_object(Cluster, pk, current_identity)
+
+    data = request.json
+    if not isinstance(data, dict) or (isinstance(data, dict) and 'node_count' not in data):
+        abort(400)
+
+    res_status, res_msg = obj.engine.resize(data['node_count'])
+
+    if not res_status:
+        logger.error('Resizing failed: {}'.format(res_msg))
+        abort(500, description=res_msg)
+
+    # get object with updated metadata
+    output = obj.engine.cluster
+    return jsonify(output)
+
+
 # Provisioners
 class ListProvisioners(ListView):
     object_class = Provisioner

--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -28,6 +28,7 @@ class BaseConfig:
     CLUSTER_OK_STATE = 'OK'
     CLUSTER_PROVISIONING_STATE = 'Deploying'
     CLUSTER_DEPROVISIONING_STATE = 'Destroying'
+    CLUSTER_RESIZING_STATE = 'Resizing'
     CLUSTER_UNKNOWN_STATE = 'Unknown'
 
     CLUSTER_STATE_ON_LIST = True

--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -121,6 +121,7 @@ class AksEngine(BaseEngine):
                 'count': kwargs.get('node_count', 1),
                 'dns_prefix': None,
                 'ports': None,
+                # TODO: fix hardcoded params
                 'vm_size': 'Standard_D2_v2',
                 'os_type': 'Linux',
                 'os_disk_size_gb': None

--- a/kqueen/engines/base.py
+++ b/kqueen/engines/base.py
@@ -133,6 +133,21 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    def resize(self, node_count):
+        """Resize the cluster related to this engine instance.
+
+        Although this function doesn't take any arguments, it is expected that
+        the implementation of the Provisioner gets ``self.cluster`` to provide the
+        relevant object which we want to resize.
+
+        Returns:
+            tuple: First item is bool (success/failure), second item is error, can be None::
+
+                (True, None)                            # successful provisioning
+                (False, 'Could not connect to backend') # failed provisioning
+        """
+        raise NotImplementedError
+
     def get_kubeconfig(self):
         """Get kubeconfig of the cluster related to this engine from backend.
 

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -156,6 +156,9 @@ class GceEngine(BaseEngine):
             logger.error(msg)
             return False, msg
 
+        self.cluster.metadata['node_count'] = node_count
+        self.cluster.save()
+
         return True, None
 
     def get_kubeconfig(self):

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -13,7 +13,8 @@ config = current_config()
 STATE_MAP = {
     'PROVISIONING': config.get('CLUSTER_PROVISIONING_STATE'),
     'RUNNING': config.get('CLUSTER_OK_STATE'),
-    'STOPPING': config.get('CLUSTER_DEPROVISIONING_STATE')
+    'STOPPING': config.get('CLUSTER_DEPROVISIONING_STATE'),
+    'RECONCILING': config.get('CLUSTER_RESIZING_STATE')
 }
 
 
@@ -135,6 +136,23 @@ class GceEngine(BaseEngine):
             # TODO: check if provisioning response is healthy
         except Exception as e:
             msg = 'Deleting cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
+            logger.error(msg)
+            return False, msg
+
+        return True, None
+
+    def resize(self, node_count, **kwargs):
+        request = self.client.projects().zones().clusters().nodePools().setSize(
+            nodePoolId='default-pool',
+            clusterId=self.cluster_id,
+            zone=self.zone,
+            body={'nodeCount': node_count},
+            projectId=self.project
+        )
+        try:
+            response = request.execute()
+        except Exception as e:
+            msg = 'Resizing cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
             logger.error(msg)
             return False, msg
 

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -150,7 +150,7 @@ class GceEngine(BaseEngine):
             projectId=self.project
         )
         try:
-            response = request.execute()
+            request.execute()
         except Exception as e:
             msg = 'Resizing cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
             logger.error(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ google-auth-httplib2==0.0.3
 
 #AKS
 azure==2.0.0
-azure-mgmt-containerservice
+azure-mgmt-containerservice==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'google-auth==1.2.1',
         'google-auth-httplib2==0.0.3',
         'azure==2.0.0',
-        'azure-mgmt-containerservice',
+        'azure-mgmt-containerservice==3.0.0',
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
This PR contains following changes:

- Fix compatibility with new version of Azure Contrainer Service API. Raise version of `azure-mgmt-containerservice` package to 3.0.0 and implement new way of getting Kubeconfig
- Add `resize` method to base engine class to allow cluster node scaling
- Add `Resizing` state for Cluster object
- Implement resize for GCE and AKS engines
- Add `cluster_resize` API endpoint