### PR TITLE
Improve engine deletion process

### DIFF
--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -184,6 +184,11 @@ class AksEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.deprovision`
         """
+        # test if cluster is considered deprovisioned by the base method
+        result, error = super(AksEngine, self).deprovision(**kwargs)
+        if result:
+            return result, error
+
         try:
             self.client.managed_clusters.delete(self.resource_group_name, self.cluster.id)
             # TODO: check if deprovisioning response is healthy

--- a/kqueen/engines/base.py
+++ b/kqueen/engines/base.py
@@ -1,6 +1,9 @@
 from kqueen.config import current_config
 
+import logging
+
 config = current_config()
+logger = logging.getLogger(__name__)
 
 
 class BaseEngine:
@@ -131,7 +134,19 @@ class BaseEngine:
                 (True, None)                            # successful provisioning
                 (False, 'Could not connect to backend') # failed provisioning
         """
-        raise NotImplementedError
+        try:
+            cluster = self.cluster_get()
+        except NotImplementedError:
+            pass
+        except Exception as e:
+            msg = 'Fetching data from backend for cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
+            logger.error(msg)
+        else:
+            if not cluster:
+                return True, None
+
+        msg = 'Deprovision method on engine {} is not implemented'.format(self.verbose_name)
+        return False, msg
 
     def resize(self, node_count):
         """Resize the cluster related to this engine instance.

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -131,6 +131,11 @@ class GceEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.deprovision`
         """
+        # test if cluster is considered deprovisioned by the base method
+        result, error = super(GceEngine, self).deprovision(**kwargs)
+        if result:
+            return result, error
+
         try:
             self.client.projects().zones().clusters().delete(projectId=self.project, zone=self.zone, clusterId=self.cluster_id).execute()
             # TODO: check if provisioning response is healthy

--- a/kqueen/engines/test_base.py
+++ b/kqueen/engines/test_base.py
@@ -8,7 +8,6 @@ required_methods = [
     'cluster_list',
     'cluster_get',
     'provision',
-    'deprovision',
     'get_kubeconfig',
     'get_progress',
 ]
@@ -40,6 +39,11 @@ class TestBaseEngine:
     def test_get_parameter_schema(self, cluster):
         engine = BaseEngine(cluster)
         assert engine.get_parameter_schema() == engine.parameter_schema
+
+    def test_deprovision(self, cluster):
+        engine = BaseEngine(cluster)
+        result, error = engine.deprovision()
+        assert result is False
 
 
 class TestAllEngines:


### PR DESCRIPTION
In BaseEngine `deprovision` method, test if cluster exists on the backend and return True if it does. Skip deletion in specific engine `deprovision` implementation if base `deprovision` returns True. This way we can delete clusters which never provisioned on the backend in the first place.