### PR TITLE
Manual engine cluster_get

### DIFF
--- a/kqueen/blueprints/api/test_cluster.py
+++ b/kqueen/blueprints/api/test_cluster.py
@@ -41,10 +41,38 @@ class TestClusterCRUD(BaseTestCRUD):
             headers=self.auth_header
         )
 
-        print('JSON response:', response.json, sep='\n')
-        print('get_dict:', self.obj.get_dict(expand=True), sep='\n')
+        # object might have been updated during GET
+        obj = self.obj.__class__.load(
+            self.namespace,
+            self.obj.id
+        )
 
-        assert response.json == self.obj.get_dict(expand=True)
+        print('JSON response:', response.json, sep='\n')
+        print('get_dict:', obj.get_dict(expand=True), sep='\n')
+
+        assert response.json == obj.get_dict(expand=True)
+
+    def test_crud_list(self):
+        response = self.client.get(
+            self.urls['list'],
+            headers=self.auth_header,
+        )
+
+        data = response.json
+
+        # object might have been updated during LIST
+        obj = self.obj.__class__.load(
+            self.namespace,
+            self.obj.id
+        )
+        obj.get_state()
+
+        assert isinstance(data, list)
+        assert len(data) == len(self.obj.__class__.list(
+            self.namespace,
+            return_objects=False)
+        )
+        assert obj.get_dict(expand=True) in data
 
     @pytest.mark.parametrize('cluster_id,status_code', [
         (uuid4(), 404),

--- a/kqueen/blueprints/api/test_crud.py
+++ b/kqueen/blueprints/api/test_crud.py
@@ -105,8 +105,14 @@ class BaseTestCRUD:
             headers=self.auth_header,
         )
 
+        # object might have been updated during GET
+        obj = self.obj.__class__.load(
+            self.namespace,
+            self.obj.id
+        )
+
         assert response.status_code == 200
-        assert response.json == self.obj.get_dict(expand=True)
+        assert response.json == obj.get_dict(expand=True)
 
     def test_crud_list(self):
         response = self.client.get(
@@ -116,12 +122,18 @@ class BaseTestCRUD:
 
         data = response.json
 
+        # object might have been updated during LIST
+        obj = self.obj.__class__.load(
+            self.namespace,
+            self.obj.id
+        )
+
         assert isinstance(data, list)
         assert len(data) == len(self.obj.__class__.list(
             self.namespace,
             return_objects=False)
         )
-        assert self.obj.get_dict(expand=True) in data
+        assert obj.get_dict(expand=True) in data
 
     def test_crud_update(self):
         data = self.get_edit_data()

--- a/kqueen/engines/test_manual.py
+++ b/kqueen/engines/test_manual.py
@@ -60,7 +60,7 @@ class TestClusterAction(ManualEngineBase):
         assert self.engine.cluster_list() == []
 
     def test_cluster_get(self):
-        assert self.engine.cluster_get() == {}
+        assert 'state' in self.engine.cluster_get()
 
     @pytest.mark.parametrize('action', ['provision', 'deprovision'])
     def test_actions(self, action):


### PR DESCRIPTION
Implement `cluster_get` method for Manual engine so it can properly work with current version of KQueen.