### PR TITLE
gce engine check refactoring

### DIFF
--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -117,7 +117,7 @@ class GceEngine(BaseEngine):
         # Client initialization
         self.service_account_info = kwargs.get('service_account_info', {})
         self.project = kwargs.get('project', '')
-        self.zone = kwargs.get('zone', '')
+        self.zone = kwargs.get('zone', '-')
         self.cluster_id = 'a' + self.cluster.id.replace('-', '')
         self.cluster_config = {
             'cluster': {
@@ -287,7 +287,7 @@ class GceEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.cluster_list`
 
-        Get list of all clusters, owned by project, both kqueen managed and others.
+        Get list of all clusters, owned by project, both kqueen managed and others in either the specified zone or all zones
         """
 
         request = self.client.projects().zones().clusters().list(projectId=self.project, zone=self.zone)
@@ -311,7 +311,8 @@ class GceEngine(BaseEngine):
                     'state': state,
                     'metadata': {
                         'Node config': cluster['nodeConfig'],
-                        'Current Master Version': cluster['currentMasterVersion']
+                        'Current Master Version': cluster['currentMasterVersion'],
+                        'Zone': cluster['zone']
                     }
                 }
                 cl.append(item)
@@ -320,10 +321,26 @@ class GceEngine(BaseEngine):
         return []
 
     @classmethod
-    def engine_status(cls):
+    def engine_status(cls, **kwargs):
+        service_account_info = kwargs.get('service_account_info', {})
+        project = kwargs.get('project', '')
+        project_zone = kwargs.get('zone', '-')
+        credentials = service_account.Credentials.from_service_account_info(service_account_info)
+        client = googleapiclient.discovery.build('container', 'v1', credentials=credentials)
+
         test_url = 'https://container.googleapis.com/v1/projects/project/zones/zone/clusters?alt=json'
         headers = {'Accept': 'application/json'}
         response = requests.get(test_url, headers=headers)
+
         if response.status_code == 401:
-            return config.get('PROVISIONER_OK_STATE')
-        return config.get('PROVISIONER_ERROR_STATE')
+            try:
+                client.projects().zones().clusters().list(projectId=project, zone=project_zone).execute()
+            except Exception as e:
+                msg = 'Failed to discover GCE project. Check that credentials is valid. Error:'
+                logger.exception(msg)
+                return config.get('PROVISIONER_UNKNOWN_STATE')
+            status = config.get('PROVISIONER_OK_STATE')
+        else:
+            status = config.get('PROVISIONER_ERROR_STATE')
+
+        return status

--- a/kqueen/engines/jenkins.py
+++ b/kqueen/engines/jenkins.py
@@ -73,13 +73,13 @@ class JenkinsEngine(BaseEngine):
         return self.client.get_job_info(self.provision_job_name, depth=1)
 
     @classmethod
-    def engine_status(cls):
+    def engine_status(cls, **kwargs):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.engine_status`
         """
         conn_kw = {
-            'username': config.get('JENKINS_USERNAME'),
-            'password': config.get('JENKINS_PASSWORD'),
+            'username': kwargs.get('username', config.get('JENKINS_USERNAME')),
+            'password': kwargs.get('password', config.get('JENKINS_PASSWORD')),
             'timeout': 10
         }
         status = config.get('PROVISIONER_UNKNOWN_STATE')

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -341,8 +341,9 @@ class Provisioner(Model, metaclass=ModelMeta):
     def engine_status(self, save=True):
         state = config.get('PROVISIONER_UNKNOWN_STATE')
         engine_class = self.get_engine_cls()
+
         if engine_class:
-            state = engine_class.engine_status()
+            state = engine_class.engine_status(**self.parameters)
         if save:
             self.state = state
             self.save()


### PR DESCRIPTION
provisioner statuses:
OK- url access, auth is success
UNKNOWN- url access, auth is failed
ERROR- url unavailable

- cluster listing check implemented in engine_status for future deatures, like 'auto attaching existing clusters into kqueen'
- jenkins engine status refactored to get kwargs instead of config ( if exist)
- added zone defaults '-' (this symbol means, that method should work for all zones)

p.p.p.s need to merge this request into gce-list brunch
then update pr https://github.com/Mirantis/kqueen/pull/233/files
and merge it to master