### PR TITLE
Provisioner alive check

### DIFF
--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -216,7 +216,7 @@ class ListProvisioners(ListView):
 
     def get_content(self, *args, **kwargs):
         provisioners = self.obj
-        if config.get('PROVISIONER_STATE_ON_LIST', True):
+        if config.get('PROVISIONER_STATE_ON_LIST'):
             try:
                 # get or establish event loop
                 try:

--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -40,6 +40,7 @@ class BaseConfig:
     PROVISIONER_UNKNOWN_STATE = 'Not Reachable'
 
     PROVISIONER_ENGINE_WHITELIST = None
+    PROVISIONER_STATE_ON_LIST = True
 
     # Timeout for cluster operations (in seconds)
     PROVISIONER_TIMEOUT = 3600

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -348,10 +348,6 @@ class Provisioner(Model, metaclass=ModelMeta):
             self.save()
         return state
 
-    def alive(self):
-        """Test availability of provisioner and return bool"""
-        return True
-
     def save(self, check_status=True):
         if check_status:
             self.state = self.engine_status(save=False)


### PR DESCRIPTION
Similar to ListCluster, check status of Provisioner on list request, so we can disallow cluster provisioning with unhealthy Provisioner object.