### PR TITLE
refactor cluster status check for manual engine

### DIFF
--- a/kqueen/engines/manual.py
+++ b/kqueen/engines/manual.py
@@ -44,14 +44,13 @@ class ManualEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.cluster_get`
         """
-        if self.cluster.kubeconfig:
-            try:
-                client = KubernetesAPI(cluster=self.cluster)
-                client.get_version()
-            except Exception as e:
-                msg = 'Fetching data from backend for cluster {} failed with following reason:'.format(self.cluster.id)
-                logger.exception(msg)
-                return {'state': config.get('CLUSTER_ERROR_STATE')}
+        try:
+            client = KubernetesAPI(cluster=self.cluster)
+            client.get_version()
+        except Exception as e:
+            msg = 'Fetching data from backend for cluster {} failed with following reason:'.format(self.cluster.id)
+            logger.exception(msg)
+            return {'state': config.get('CLUSTER_ERROR_STATE')}
         return {'state': config.get('CLUSTER_OK_STATE')}
 
     def provision(self):


### PR DESCRIPTION
'if' condition is useless and allows to skip check -> as result Green cluster state
instead of Red

following check tested on next cases:
1) +  normal config from gce == no trace, green
2) +- normal config from gce with some k8s options missed == json-trace and important l8s trace == '''api_1   | kubernetes.config.config_exception.ConfigException: Invalid kube-config file. Expected key contexts in kube-config'''
3) - simple text file  == json trace, red status

relatedd bug: https://mirantis.jira.com/browse/PROD-17996