### PR TITLE
Fix LDAP authentication

### DIFF
--- a/kqueen/auth/common.py
+++ b/kqueen/auth/common.py
@@ -13,12 +13,10 @@ logger = logging.getLogger('kqueen_api')
 
 
 def get_auth_instance(name):
-    config = current_config()
-    auth_config = config.get("AUTH", {}).get(name, {})
+    default = {'local': {'engine': 'LocalAuth', 'param': {}}}
 
-    # Default engine, AUTH in config is empty
-    if name == 'local':
-        auth_config = {'engine': 'LocalAuth', 'param': {}}
+    config = current_config()
+    auth_config = config.get("AUTH", default).get(name, {})
 
     module = importlib.import_module('kqueen.auth')
     auth_engine = auth_config.get('engine')

--- a/kqueen/auth/common.py
+++ b/kqueen/auth/common.py
@@ -19,7 +19,7 @@ def get_auth_instance(name):
     auth_config = config.get("AUTH", {}).get(name, {})
 
     # If user auth is not specified clearly, use local
-    if name == 'local' or None:
+    if name == 'local' or name is None:
         auth_config = {'engine': 'LocalAuth', 'param': {}}
 
     module = importlib.import_module('kqueen.auth')

--- a/kqueen/auth/test_common.py
+++ b/kqueen/auth/test_common.py
@@ -1,0 +1,23 @@
+from . import common
+from .ldap import LDAPAuth
+from .local import LocalAuth
+
+import pytest
+import os
+
+@pytest.mark.parametrize('name, result',
+                         [('ldap', LDAPAuth),
+                          ('local', LocalAuth)
+                          ])
+def test_get_auth_instance(name, result):
+    os.environ['KQUEEN_CONFIG_FILE'] = 'config/test.py'
+    auth_instance = common.get_auth_instance(name)
+    assert isinstance(auth_instance, result)
+    del os.environ['KQUEEN_CONFIG_FILE']
+
+
+def test_raises_unknown_engine_class():
+    with pytest.raises(Exception, match=r'Authentication engine class name is not provided.'):
+        common.get_auth_instance('non-existent')
+
+#TODO: add more tests

--- a/kqueen/auth/test_common.py
+++ b/kqueen/auth/test_common.py
@@ -5,7 +5,6 @@ from .local import LocalAuth
 import pytest
 
 
-
 @pytest.mark.parametrize('name, result',
                          [('ldap', LDAPAuth),
                           ('local', LocalAuth)

--- a/kqueen/auth/test_common.py
+++ b/kqueen/auth/test_common.py
@@ -3,7 +3,7 @@ from .ldap import LDAPAuth
 from .local import LocalAuth
 
 import pytest
-import os
+
 
 
 @pytest.mark.parametrize('name, result',
@@ -11,14 +11,12 @@ import os
                           ('local', LocalAuth)
                           ])
 def test_get_auth_instance(name, result):
-    os.environ['KQUEEN_CONFIG_FILE'] = 'config/test.py'
     auth_instance = common.get_auth_instance(name)
     assert isinstance(auth_instance, result)
-    del os.environ['KQUEEN_CONFIG_FILE']
 
 
 def test_raises_unknown_engine_class():
-    with pytest.raises(Exception, match=r'Authentication engine class name is not provided.'):
+    with pytest.raises(Exception, match=r'Authentication type is set to non-existent'):
         common.get_auth_instance('non-existent')
 
 # TODO: add more tests

--- a/kqueen/auth/test_common.py
+++ b/kqueen/auth/test_common.py
@@ -5,6 +5,7 @@ from .local import LocalAuth
 import pytest
 import os
 
+
 @pytest.mark.parametrize('name, result',
                          [('ldap', LDAPAuth),
                           ('local', LocalAuth)
@@ -20,4 +21,4 @@ def test_raises_unknown_engine_class():
     with pytest.raises(Exception, match=r'Authentication engine class name is not provided.'):
         common.get_auth_instance('non-existent')
 
-#TODO: add more tests
+# TODO: add more tests


### PR DESCRIPTION
ldap class, that is responsable for authentication was not called correctly.
Now parameters from config file are used properly to find ldap authentication
 class correctly.
Add corresponding test.