### PR TITLE
refactor nginx proxy service

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Domain name for service. Should be equal with name in generated ssl-certificate
+NGINX_DEBUG=True
+# Domain name for service. Should be equal with name in generated ssl-certificate
+NGINX_VHOSTNAME=demo.kqueen.net
+# Directory path for certificates in container.Finally it look like $NGINX_SSL_CERTIFICATE_DIR/$NGINX_VHOSTNAME
+NGINX_SSL_CERTIFICATE_DIR=/mnt/letsencrypt

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -25,13 +25,24 @@ services:
     depends_on:
       - etcd
   proxy:
-    build: ./prod/nginx/
+    env_file:
+      - .env
+    build:
+      context: ./prod/nginx/
+      # TODO: check that NGINX_VHOSTNAME from .env file  is equal with generated ssl-cert
+      args:
+        - DEBUG=${NGINX_DEBUG}
+        - VHOSTNAME=${NGINX_VHOSTNAME}
+        - SSL_CERTIFICATE_DIR=${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}
+        - SSL_CERTIFICATE_PATH=${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}/fullchain.cer
+        - SSL_CERTIFICATE_KEY_PATH=${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}/${NGINX_VHOSTNAME}.key
+        - SSL_TRUSTED_CERTIFICATE_PATH=${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}/ca.cer
     restart: always
     ports:
       - 443:443
       - 80:80
     volumes:
-      - /mnt/storage/kqueen/certs/:/mnt/letsencrypt/demo.kqueen.net/:ro
+      - /mnt/storage/kqueen/certs/:${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}/:ro
     volumes_from:
       - ui:ro
     depends_on:

--- a/prod/nginx/Dockerfile
+++ b/prod/nginx/Dockerfile
@@ -4,7 +4,18 @@ LABEL maintainer="tkukral@mirantis.com"
 # environment
 ENV DIR_CONF /etc/nginx/conf.d/
 ENV DIR_APP /var/www/app/
-ENV VHOSTNAME demo.kqueen.net
+ARG DEBUG
+ENV DEBUG ${DEBUG:-False}
+ARG VHOSTNAME
+ENV VHOSTNAME ${VHOSTNAME:-demo.kqueen.net}
+ARG SSL_CERTIFICATE_DIR
+ENV SSL_CERTIFICATE_DIR ${SSL_CERTIFICATE_DIR:-/mnt/letsencrypt/$VHOSTNAME}
+ARG SSL_CERTIFICATE_PATH
+ENV SSL_CERTIFICATE_PATH ${SSL_CERTIFICATE_PATH:-$SSL_CERTIFICATE_DIR/fullchain.cer}
+ARG SSL_CERTIFICATE_KEY_PATH
+ENV SSL_CERTIFICATE_KEY_PATH ${SSL_CERTIFICATE_KEY_PATH:-$SSL_CERTIFICATE_DIR/$VHOSTNAME.key}
+ARG SSL_TRUSTED_CERTIFICATE_PATH
+ENV SSL_TRUSTED_CERTIFICATE_PATH ${SSL_TRUSTED_CERTIFICATE_PATH:-$SSL_CERTIFICATE_DIR/ca.cer}
 
 # flush nginx config
 RUN rm -v /etc/nginx/conf.d/*
@@ -13,4 +24,10 @@ RUN rm -v /etc/nginx/conf.d/*
 COPY vhost.conf $DIR_CONF
 
 # edit vhost.conf
-RUN sed -i "s/vhostname/$VHOSTNAME/g" "$DIR_CONF/vhost.conf"
+RUN sed -i "s@vhostname@$VHOSTNAME@g" "$DIR_CONF/vhost.conf" && \
+    sed -i "s@ssl_certificate_path@$SSL_CERTIFICATE_PATH@g" "$DIR_CONF/vhost.conf" && \
+    sed -i "s@ssl_certificate_key_path@$SSL_CERTIFICATE_KEY_PATH@g" "$DIR_CONF/vhost.conf" && \
+    sed -i "s@ssl_trusted_certificate_path@$SSL_TRUSTED_CERTIFICATE_PATH@g" "$DIR_CONF/vhost.conf"
+
+#debug mode
+RUN  if [ "$DEBUG" = True ]; then (echo 'Check nginx configuration: '; cat "$DIR_CONF/vhost.conf"; echo 'Check defined environment variables: '; env); fi

--- a/prod/nginx/vhost.conf
+++ b/prod/nginx/vhost.conf
@@ -27,8 +27,9 @@ server { # https://vhostname
 	access_log /dev/stdout main;
 	error_log /dev/stdout info;
 
-	ssl_certificate /mnt/letsencrypt/vhostname/fullchain.cer;
-	ssl_certificate_key /mnt/letsencrypt/vhostname/vhostname.key;
+	ssl_certificate ssl_certificate_path;
+	ssl_certificate_key ssl_certificate_key_path;
+
 	ssl_session_timeout 1d;
 	ssl_session_cache shared:SSL:50m;
 
@@ -49,7 +50,7 @@ server { # https://vhostname
 	#ssl_stapling_verify on;
 
 	## verify chain of trust of OCSP response using Root CA and Intermediate certs
-	ssl_trusted_certificate /mnt/letsencrypt/vhostname/ca.cer;
+	ssl_trusted_certificate ssl_trusted_certificate_path;
 
 	client_max_body_size 64M;
 


### PR DESCRIPTION
- increase code visibility
- provide possibility of managing certs quickly and easily
- remove hardcode
- provide valid instructions as comments and also as release notes(see ex below)
```
Configure variables in .env file from Nginx section:
NGINX_VHOSTNAME - domain name for Kqueen service. Should be equal with domain name in generated certificates.
NGINX_SSL_CERTIFICATE_DIR - Mapped directory for certificates forwarding into docker container.

Check proxy service configuration in docker-compose.production.yml. Pay attention on following variables:

VHOSTNAME - domain name for Kqueen service. Should be equal with domain name in generated certificates. Default: Using variable from .env file, named NGINX_VHOSTNAME
SSL_CERTIFICATE_DIR - Mapped directory for certificates forwarding into docker container. Default: Using variable from .env file, named NGINX_SSL_CERTIFICATE_DIR/NGINX_VHOSTNAME
SSL_CERTIFICATE_PATH - Path for cert+key certificate. Default: $SSL_CERTIFICATE_DIR/fullchain.cer
SSL_CERTIFICATE_KEY_PATH -  Path for certificate key. Default: $SSL_CERTIFICATE_DIR/$VHOSTNAME.key
SSL_TRUSTED_CERTIFICATE_PATH - Path for certificate only. Default: $SSL_CERTIFICATE_DIR/ca.cer

Check that local certificates naming equal to defined in variables.

Map volumes with certificates. Pay attention that destination path should be equal with SSL_CERTIFICATE_DIR. Example:

    volumes:
      - /your/local/cert/storage/kqueen/certs/:${NGINX_SSL_CERTIFICATE_DIR}/${NGINX_VHOSTNAME}:ro

Build proxy service image:

docker-compose -f docker-compose.production.yml build --no-cache

Re-run production services:

docker-compose -f docker-compose.yml -f docker-compose.production.yml  up --force-recreate
```
duplicated from https://docs.google.com/document/d/1Bnor6D78fVzOndie52wFHVVbgV0daTOHrVP1IgKZvic/edit?usp=sharing