### PR TITLE
refactor kqueen metrics mechanism

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test=pytest
 python_files = tests.py test_*.py tests_*.py *_tests.py
 env =
 	KQUEEN_CONFIG_FILE=config/test.py
-	prometheus_multiproc_dir=/tmp/prometheus_client/
+	D:prometheus_multiproc_dir=/tmp/prometheus_client/
 
 [flake8]
 ignore = E501


### PR DESCRIPTION
previously i cant get users/orgs metrics with:
'''localhost:5000/metrics/'''

- kqueen metrics updating
- logging for above operation (info level)
- prevent overriding env variables for pytest to avoid issues related to directory doesnot exist:
```FileNotFoundError: [Errno 2] No such file or directory: '/tmp/prometheus_client/gauge_all_5850.db'```
    it happens when setup.cfg overrides env var for pytest run

Notes:
We export all application metrics on /metrics and this metric can scraped by any external Prometheus instance. There two ways to authenticate to get this endpoint:

1. Provided valid token in header

TOKEN=$(curl -s -H "Content-Type: application/json" --data '{"username":"admin","password":"default"}' -X POST localhost:5000/api/v1/auth | jq -r '.access_token'); echo $TOKEN; curl -H "Authorization: Bearer $TOKEN"
And then go to localhost:5000/metrics

2. Add scraper IP address to PROMETHEUS_WHITELIST configuration and then

Go to {prometheus_ip}:{port}/metrics

review-docs: https://docs.google.com/document/d/1Bnor6D78fVzOndie52wFHVVbgV0daTOHrVP1IgKZvic/edit#