### PR TITLE
Update logging settings

### DIFF
--- a/kqueen/config/demo.py
+++ b/kqueen/config/demo.py
@@ -3,7 +3,6 @@ from .base import BaseConfig
 
 class Config(BaseConfig):
     DEBUG = False
-    LOG_LEVEL = 'DEBUG'
     LOG_CONFIG = 'kqueen/utils/logger_config.yml'
 
     KQUEEN_HOST = '0.0.0.0'

--- a/kqueen/config/dev.py
+++ b/kqueen/config/dev.py
@@ -3,7 +3,6 @@ from .base import BaseConfig
 
 class Config(BaseConfig):
     DEBUG = True
-    LOG_LEVEL = 'INFO'
     LOG_CONFIG = 'kqueen/utils/logger_config.yml'
 
     # App secret

--- a/kqueen/config/prod.py
+++ b/kqueen/config/prod.py
@@ -3,7 +3,6 @@ from .base import BaseConfig
 
 class Config(BaseConfig):
     DEBUG = False
-    LOG_LEVEL = 'DEBUG'
     LOG_CONFIG = 'kqueen/utils/logger_config.yml'
 
     KQUEEN_HOST = '0.0.0.0'

--- a/kqueen/config/test.py
+++ b/kqueen/config/test.py
@@ -3,7 +3,6 @@ from .base import BaseConfig
 
 class Config(BaseConfig):
     DEBUG = True
-    LOG_LEVEL = 'DEBUG'
     LOG_CONFIG = 'kqueen/utils/logger_config.yml'
 
     # App secret

--- a/kqueen/server.py
+++ b/kqueen/server.py
@@ -17,7 +17,7 @@ import logging
 
 # Logging configuration
 config = current_config(config_file=None)
-setup_logging(config.get('LOG_CONFIG'), config.get('LOG_LEVEL'))
+setup_logging(config.get('LOG_CONFIG'), config.get('DEBUG'))
 logger = logging.getLogger('kqueen_api')
 
 cache = SimpleCache()
@@ -50,7 +50,6 @@ def create_app(config_file=None):
         raise ImproperlyConfigured('The SECRET_KEY must be set and longer than 16 chars.')
 
     app.config.from_mapping(config.to_dict())
-    logger.info('Loading configuration from {}'.format(config.source_file))
 
     # setup database
     app.db = EtcdBackend()

--- a/kqueen/utils/loggers.py
+++ b/kqueen/utils/loggers.py
@@ -4,12 +4,21 @@ import logging.config
 import logging
 
 
-def setup_logging(path='kqueen/utils/logger_config.yml', default_level=logging.INFO):
+def setup_logging(path, debug_mode):
+    default_level = 'INFO'
 
     if os.path.exists(path):
         with open(path, 'rt') as f:
             try:
                 config = yaml.safe_load(f.read())
+                loggers = config['loggers']
+                for logger, value in loggers.items():
+                    if debug_mode:
+                        loggers[logger]['level'] = 'DEBUG'
+                    else:
+                        current_level = value.get('level')
+                        loggers[logger]['level'] = default_level if not current_level else current_level
+
                 logging.config.dictConfig(config)
             except Exception as e:
                 print(e)


### PR DESCRIPTION
   * Remove LOG_LEVEL set up from the main config

    Currently, logging config is used to set up log level for each logger.
    So there is no need to provide default log level. If config provided,
    it will be ignored anyway and leads to misunderstandings.
    So now all log level set up are made in a separate logging config file.

    * Change default general_file_handler  log level

    Also, log level of console logger is changed to INFO instead of log level of
    corresponding handler. It was made, because handler has a higher priority
    and if user will change log level to debug, it still remain INFO or user
     have to change both places, which is inconvenient.

    * If Debug is True in config file, set debug log level automatically

      Otherwise keep log level from config

    * Move default logging config path from setup_logging definition to its call

    Otherwise default value will never applied, cause None will be used