### PR TITLE
Check Provisioner state before saving and provisioning new Cluster

### DIFF
--- a/kqueen/blueprints/api/test_cluster.py
+++ b/kqueen/blueprints/api/test_cluster.py
@@ -226,6 +226,30 @@ class TestClusterCRUD(BaseTestCRUD):
 
         assert response.status_code == 500
 
+    @pytest.mark.parametrize('provisioner_state', [
+        config.get('PROVISIONER_UNKNOWN_STATE'),
+        config.get('PROVISIONER_ERROR_STATE')
+    ])
+    def test_provision_failed_with_unhealthy_provisioner(self, provisioner, user, provisioner_state):
+        provisioner.state = provisioner_state
+        provisioner.save(check_status=False)
+        user.save()
+
+        post_data = {
+            'name': 'Testing cluster',
+            'provisioner': 'Provisioner:{}'.format(provisioner.id),
+            'owner': 'User:{}'.format(user.id)
+        }
+
+        response = self.client.post(
+            url_for('api.cluster_create'),
+            data=json.dumps(post_data),
+            headers=self.auth_header,
+            content_type='application/json',
+        )
+
+        assert response.status_code == 500
+
     def test_return_400_missing_json(self):
         response = self.client.post(
             url_for('api.cluster_create'),

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -110,6 +110,13 @@ class ListClusters(ListView):
 class CreateCluster(CreateView):
     object_class = Cluster
 
+    def save_object(self):
+        if self.obj.provisioner.state != config.get('PROVISIONER_OK_STATE'):
+            msg = 'Cannot create cluster with malfunctioning Provisioner'
+            logger.error('Provisioning failed: {}'.format(msg))
+            abort(500, description=msg)
+        return super().save_object()
+
     def after_save(self):
         # start provisioning
         prov_status, prov_msg = self.obj.engine.provision()

--- a/kqueen/conftest.py
+++ b/kqueen/conftest.py
@@ -49,6 +49,7 @@ def cluster():
         engine='kqueen.engines.ManualEngine',
         owner=_user
     )
+    prov.state = config.get('PROVISIONER_OK_STATE')
     prov.save(check_status=False)
 
     create_kwargs = {

--- a/kqueen/engines/test_manual.py
+++ b/kqueen/engines/test_manual.py
@@ -1,7 +1,7 @@
 from .manual import ManualEngine
 from flask import url_for
+from kqueen.config import current_config
 from kqueen.conftest import auth_header
-from kqueen.conftest import config
 from kqueen.conftest import user
 from kqueen.models import Cluster
 from kqueen.models import Provisioner
@@ -10,6 +10,7 @@ import json
 import pytest
 import yaml
 
+config = current_config()
 KUBECONFIG = yaml.load(open('kubeconfig_localhost', 'r').read())
 CLUSTER_METADATA = {
     'minion_count': 10,

--- a/kqueen/engines/test_manual.py
+++ b/kqueen/engines/test_manual.py
@@ -1,6 +1,7 @@
 from .manual import ManualEngine
 from flask import url_for
 from kqueen.conftest import auth_header
+from kqueen.conftest import config
 from kqueen.conftest import user
 from kqueen.models import Cluster
 from kqueen.models import Provisioner
@@ -33,6 +34,7 @@ class ManualEngineBase:
         }
 
         prov = Provisioner(_user.namespace, **create_kwargs_provisioner)
+        prov.state = config.get('PROVISIONER_OK_STATE')
         prov.save(check_status=False)
 
         self.create_kwargs_cluster = {


### PR DESCRIPTION
Provisioner state is updated on demand so we can rely on it and disallow creation of new Cluster object if Provisioner state is unhealthy.