### PR TITLE
Extend policy on user deletion

### DIFF
--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -412,6 +412,10 @@ class UpdateUser(UpdateView):
 class DeleteUser(DeleteView):
     object_class = User
 
+    def get_policy_key(self):
+        policy_key = super().get_policy_key()
+        return '{}_{}'.format(policy_key, self.obj.role)
+
 
 api.add_url_rule('/users', view_func=ListUsers.as_view('user_list'))
 api.add_url_rule('/users', view_func=CreateUser.as_view('user_create'))

--- a/kqueen/config/default_policy.json
+++ b/kqueen/config/default_policy.json
@@ -15,7 +15,9 @@
     "provisioner:list": "ALL",
     "provisioner:update": "ALL",
     "user:create": "IS_ADMIN",
-    "user:delete": "IS_ADMIN",
+    "user:delete_member": "IS_ADMIN",
+    "user:delete_admin": "IS_ADMIN",
+    "user:delete_superadmin": "IS_SUPERADMIN",
     "user:get": "ALL",
     "user:list": "ALL",
     "user:update": "ADMIN_OR_OWNER"


### PR DESCRIPTION
Before admin user was able to delete superadmin.
This change extends policy settings, so permissions
now it is defined for each user role.