### PR TITLE
[UI] Add UUID validator to AKS ids

### DIFF
--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -36,7 +36,8 @@ class AksEngine(BaseEngine):
                 'type': 'text',
                 'label': 'Client ID',
                 'validators': {
-                    'required': True
+                    'required': True,
+                    'uuid': True
                 }
             },
             'secret': {
@@ -50,14 +51,16 @@ class AksEngine(BaseEngine):
                 'type': 'text',
                 'label': 'Tenant ID',
                 'validators': {
-                    'required': True
+                    'required': True,
+                    'uuid': True
                 }
             },
             'subscription_id': {
                 'type': 'text',
                 'label': 'Subscription ID',
                 'validators': {
-                    'required': True
+                    'required': True,
+                    'uuid': True
                 }
             },
             'resource_group_name': {


### PR DESCRIPTION
RFC4122 is a standart, described UUID format.
AKS engine uses uuid to store main parameters, so it's
important to validate data before cluster provisioning.