### PR TITLE
Remove useless config defining method

### DIFF
--- a/kqueen/auth/common.py
+++ b/kqueen/auth/common.py
@@ -1,6 +1,6 @@
 """Authentication methods for API."""
 
-from kqueen.config import current_config
+from kqueen.config.utils import kqueen_config
 from kqueen.models import Organization
 from kqueen.models import User
 from uuid import uuid4
@@ -15,8 +15,7 @@ logger = logging.getLogger('kqueen_api')
 def get_auth_instance(name):
     # Default type is local auth
 
-    config = current_config()
-    auth_config = config.get("AUTH", {}).get(name, {})
+    auth_config = kqueen_config.get("AUTH", {}).get(name, {})
 
     # If user auth is not specified clearly, use local
     if name == 'local' or name is None:
@@ -94,8 +93,7 @@ def identity(payload):
 
 
 def encrypt_password(_password):
-    config = current_config()
-    rounds = config.get('BCRYPT_ROUNDS', 12)
+    rounds = kqueen_config.get('BCRYPT_ROUNDS', 12)
     password = str(_password).encode('utf-8')
     encrypted = bcrypt.hashpw(password, bcrypt.gensalt(rounds)).decode('utf-8')
     return encrypted

--- a/kqueen/blueprints/api/test_cluster.py
+++ b/kqueen/blueprints/api/test_cluster.py
@@ -1,13 +1,11 @@
+from kqueen.config.utils import kqueen_config
 from .test_crud import BaseTestCRUD
 from flask import url_for
-from kqueen.config import current_config
 from kqueen.conftest import cluster
 from uuid import uuid4
 
 import json
 import pytest
-
-config = current_config()
 
 
 class TestClusterCRUD(BaseTestCRUD):
@@ -227,8 +225,8 @@ class TestClusterCRUD(BaseTestCRUD):
         assert response.status_code == 500
 
     @pytest.mark.parametrize('provisioner_state', [
-        config.get('PROVISIONER_UNKNOWN_STATE'),
-        config.get('PROVISIONER_ERROR_STATE')
+        kqueen_config.get('PROVISIONER_UNKNOWN_STATE'),
+        kqueen_config.get('PROVISIONER_ERROR_STATE')
     ])
     def test_provision_failed_with_unhealthy_provisioner(self, provisioner, user, provisioner_state):
         provisioner.state = provisioner_state
@@ -282,7 +280,7 @@ class TestClusterCRUD(BaseTestCRUD):
             self.metadata = {'executed': True}
             self.save()
 
-            return config.get('CLUSTER_UNKNOWN_STATE')
+            return kqueen_config.get('CLUSTER_UNKNOWN_STATE')
 
         monkeypatch.setattr(self.obj.__class__, 'get_state', fake_get_state)
 

--- a/kqueen/blueprints/api/test_crud.py
+++ b/kqueen/blueprints/api/test_crud.py
@@ -1,11 +1,9 @@
+from kqueen.config.utils import kqueen_config
 from flask import url_for
 from kqueen.conftest import auth_header, user_with_namespace, get_auth_token
-from kqueen.config import current_config
 
 import json
 import pytest
-
-config = current_config()
 
 
 @pytest.mark.usefixtures('client_class')
@@ -234,7 +232,7 @@ class BaseTestCRUD:
             auth_header = get_auth_token(self.client, u)
             headers = {
                 'Authorization': '{} {}'.format(
-                    config.get('JWT_AUTH_HEADER_PREFIX'),
+                    kqueen_config.get('JWT_AUTH_HEADER_PREFIX'),
                     auth_header
                 )
             }
@@ -299,7 +297,7 @@ class BaseTestCRUD:
             auth_header = get_auth_token(self.client, u)
             headers = {
                 'Authorization': '{} {}'.format(
-                    config.get('JWT_AUTH_HEADER_PREFIX'),
+                    kqueen_config.get('JWT_AUTH_HEADER_PREFIX'),
                     auth_header
                 )
             }

--- a/kqueen/blueprints/api/test_organization.py
+++ b/kqueen/blueprints/api/test_organization.py
@@ -1,11 +1,9 @@
+from kqueen.config.utils import kqueen_config
 from .test_crud import BaseTestCRUD
 from flask import url_for
-from kqueen.config import current_config
 from kqueen.conftest import organization
 
 import pytest
-
-config = current_config()
 
 
 class TestOrganizationCRUD(BaseTestCRUD):
@@ -39,7 +37,7 @@ class TestOrganizationCRUD(BaseTestCRUD):
     def test_policy(self):
         url = url_for('api.organization_policy', pk=self.obj.id)
 
-        policies = config.get('DEFAULT_POLICIES', {})
+        policies = kqueen_config.get('DEFAULT_POLICIES', {})
         if hasattr(self.obj, 'policy') and self.obj.policy:
             policies.update(self.obj.policy)
 

--- a/kqueen/blueprints/api/test_user.py
+++ b/kqueen/blueprints/api/test_user.py
@@ -1,13 +1,11 @@
 from .test_crud import BaseTestCRUD
 from flask import url_for
 from kqueen.conftest import user
-from kqueen.config import current_config
+from kqueen.config.utils import kqueen_config
 
 import bcrypt
 import json
 import pytest
-
-config = current_config()
 
 
 class TestUserCRUD(BaseTestCRUD):
@@ -42,7 +40,7 @@ class TestUserCRUD(BaseTestCRUD):
             content_type='application/json')
 
         return {'Authorization': '{header_prefix} {token}'.format(
-            header_prefix=config.get('JWT_AUTH_HEADER_PREFIX'),
+            header_prefix=kqueen_config.get('JWT_AUTH_HEADER_PREFIX'),
             token=response.json['access_token'],
         )}
 

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -1,3 +1,5 @@
+from kqueen.config.utils import kqueen_config
+
 from .generic_views import CreateView
 from .generic_views import DeleteView
 from .generic_views import GetView
@@ -17,14 +19,12 @@ from kqueen.models import Cluster
 from kqueen.models import Organization
 from kqueen.models import Provisioner
 from kqueen.models import User
-from kqueen.config import current_config
 
 import asyncio
 import logging
 import os
 import yaml
 
-config = current_config()
 logger = logging.getLogger('kqueen_api')
 
 api = Blueprint('api', __name__)
@@ -84,7 +84,7 @@ class ListClusters(ListView):
 
     def get_content(self, *args, **kwargs):
         clusters = self.obj
-        if config.get('CLUSTER_STATE_ON_LIST'):
+        if kqueen_config.get('CLUSTER_STATE_ON_LIST'):
             try:
                 # get or establish event loop
                 try:
@@ -111,7 +111,7 @@ class CreateCluster(CreateView):
     object_class = Cluster
 
     def save_object(self):
-        if self.obj.provisioner.state != config.get('PROVISIONER_OK_STATE'):
+        if self.obj.provisioner.state != kqueen_config.get('PROVISIONER_OK_STATE'):
             msg = 'Cannot create cluster with malfunctioning Provisioner'
             logger.error('Provisioning failed: {}'.format(msg))
             abort(500, description=msg)
@@ -123,7 +123,7 @@ class CreateCluster(CreateView):
 
         if not prov_status:
             logger.error('Provisioning failed: {}'.format(prov_msg))
-            self.obj.state = config.get('CLUSTER_ERROR_STATE')
+            self.obj.state = kqueen_config.get('CLUSTER_ERROR_STATE')
             abort(500, description=prov_msg)
 
 
@@ -195,7 +195,7 @@ def cluster_progress(pk):
         progress = {
             'response': 500,
             'progress': 0,
-            'result': config.get('CLUSTER_UNKNOWN_STATE')
+            'result': kqueen_config.get('CLUSTER_UNKNOWN_STATE')
         }
     return jsonify(progress)
 
@@ -237,7 +237,7 @@ class ListProvisioners(ListView):
 
     def get_content(self, *args, **kwargs):
         provisioners = self.obj
-        if config.get('PROVISIONER_STATE_ON_LIST'):
+        if kqueen_config.get('PROVISIONER_STATE_ON_LIST'):
             try:
                 # get or establish event loop
                 try:
@@ -347,7 +347,7 @@ api.add_url_rule('/organizations/<uuid:pk>', view_func=DeleteOrganization.as_vie
 @jwt_required()
 def organization_policy(pk):
     obj = get_object(Organization, pk, current_identity)
-    policies = config.get('DEFAULT_POLICIES', {})
+    policies = kqueen_config.get('DEFAULT_POLICIES', {})
     if hasattr(obj, 'policy') and obj.policy:
         policies.update(obj.policy)
 

--- a/kqueen/config/tests.py
+++ b/kqueen/config/tests.py
@@ -1,5 +1,4 @@
-from .utils import current_config
-from .utils import select_file
+from kqueen.config.utils import kqueen_config
 from kqueen.server import create_app
 from .base import BaseConfig
 
@@ -15,36 +14,6 @@ file_parametrization = [
 ]
 
 
-class TestSelectConfig:
-    @pytest.mark.parametrize('config_file,req', [
-        ('/tmp/test.py', '/tmp/test.py'),
-        (None, 'config/test.py'),
-        ('', 'config/test.py'),
-    ])
-    def test_select_config(self, config_file, req):
-        assert select_file(config_file) == req
-
-    @pytest.mark.parametrize('config_file,req', [
-        ('/tmp/test.py', '/tmp/test.py'),
-        (None, 'config/dev.py'),
-        ('', 'config/dev.py'),
-    ])
-    def test_select_config_from_envvar(self, monkeypatch, config_file, req):
-        monkeypatch.setenv(config_envvar, config_file)
-        assert select_file() == req
-
-
-class TestCurrentConfig:
-    @pytest.mark.parametrize('config_file', [
-        'config/dev.py',
-        'config/test.py',
-    ])
-    def test_current_config(self, config_file):
-        config = current_config(config_file)
-
-        assert config.source_file == select_file(config_file)
-
-
 class TestConfigFromEnv:
     @pytest.mark.parametrize('name,value', [
         ('KQUEEN_DUMMY', '123'),
@@ -52,11 +21,10 @@ class TestConfigFromEnv:
     ])
     def test_env_var(self, monkeypatch, name, value):
         monkeypatch.setenv(name, value)
-        config = current_config()
 
         config_key_name = name[7:]
 
-        assert config.get(config_key_name) == value
+        assert kqueen_config.get(config_key_name) == value
 
     def test_env_var_in_app(self, monkeypatch):
         monkeypatch.setenv('KQUEEN_DUMMY', '123')

--- a/kqueen/config/utils.py
+++ b/kqueen/config/utils.py
@@ -6,28 +6,6 @@ CONFIG_FILE_DEFAULT = 'config/dev.py'
 logger = logging.getLogger('kqueen_api')
 
 
-def select_file(config_file=None):
-    """
-    Select file to be used as a configuration.
-
-    Attributes:
-        config_file (str): Filename to be used as a configuration file
-
-    Returns:
-        str: filename to be used as a configuration file
-    """
-
-    if not config_file or config_file == 'None':
-        config_file = os.environ.get('KQUEEN_CONFIG_FILE')
-        logger.debug('Config file from env variable: {}'.format(config_file))
-
-    if not config_file or config_file == 'None':
-        config_file = CONFIG_FILE_DEFAULT
-        logger.debug('Config file, using default: {}'.format(config_file))
-
-    return config_file
-
-
 def apply_env_changes(config, prefix='KQUEEN_'):
     """
     Read env variables starting with prefix and apply
@@ -45,8 +23,8 @@ def apply_env_changes(config, prefix='KQUEEN_'):
             setattr(config, config_key_name, value)
 
 
-def current_config(config_file=None):
-    read_file = select_file(config_file)
+def current_config():
+    read_file = os.environ.get('KQUEEN_CONFIG_FILE', CONFIG_FILE_DEFAULT)
     logger.debug('Loading config from {}'.format(read_file))
 
     module_name = read_file.replace('/', '.').replace('.py', '')
@@ -58,3 +36,6 @@ def current_config(config_file=None):
     setattr(config, 'source_file', read_file)
 
     return config
+
+
+kqueen_config = current_config()

--- a/kqueen/conftest.py
+++ b/kqueen/conftest.py
@@ -1,6 +1,6 @@
 """Configuration and fixtures for pytest."""
+from kqueen.config.utils import kqueen_config
 from faker import Faker
-from kqueen.config import current_config
 from kqueen.models import Cluster
 from kqueen.models import Organization
 from kqueen.models import Provisioner
@@ -14,7 +14,6 @@ import pytest
 import uuid
 import yaml
 
-config = current_config()
 fake = Faker()
 
 
@@ -49,14 +48,14 @@ def cluster():
         engine='kqueen.engines.ManualEngine',
         owner=_user
     )
-    prov.state = config.get('PROVISIONER_OK_STATE')
+    prov.state = kqueen_config.get('PROVISIONER_OK_STATE')
     prov.save(check_status=False)
 
     create_kwargs = {
         'id': _uuid,
         'name': 'Name for cluster {}'.format(_uuid),
         'provisioner': prov,
-        'state': config.get('CLUSTER_UNKNOWN_STATE'),
+        'state': kqueen_config.get('CLUSTER_UNKNOWN_STATE'),
         'kubeconfig': yaml.load(open('kubeconfig_localhost', 'r').read()),
         'created_at': datetime.datetime.utcnow().replace(microsecond=0),
         'owner': _user
@@ -126,7 +125,7 @@ def auth_header(client):
 
     return {
         'Authorization': '{token_prefix} {token}'.format(
-            token_prefix=config.get('JWT_AUTH_HEADER_PREFIX'),
+            token_prefix=kqueen_config.get('JWT_AUTH_HEADER_PREFIX'),
             token=token,
         ),
         'X-Test-Namespace': _user.namespace,

--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -1,4 +1,4 @@
-from kqueen.config import current_config
+from kqueen.config.utils import kqueen_config
 from kqueen.engines.base import BaseEngine
 
 from azure.common.credentials import ServicePrincipalCredentials
@@ -13,14 +13,13 @@ import base64
 import yaml
 
 logger = logging.getLogger('kqueen_api')
-config = current_config()
 
 STATE_MAP = {
-    'Creating': config.get('CLUSTER_PROVISIONING_STATE'),
-    'Succeeded': config.get('CLUSTER_OK_STATE'),
-    'Deleting': config.get('CLUSTER_DEPROVISIONING_STATE'),
-    'Failed': config.get('CLUSTER_ERROR_STATE'),
-    'Updating': config.get('CLUSTER_RESIZING_STATE')
+    'Creating': kqueen_config.get('CLUSTER_PROVISIONING_STATE'),
+    'Succeeded': kqueen_config.get('CLUSTER_OK_STATE'),
+    'Deleting': kqueen_config.get('CLUSTER_DEPROVISIONING_STATE'),
+    'Failed': kqueen_config.get('CLUSTER_ERROR_STATE'),
+    'Updating': kqueen_config.get('CLUSTER_RESIZING_STATE')
 }
 
 
@@ -273,7 +272,7 @@ class AksEngine(BaseEngine):
             msg = 'Fetching data from backend for cluster {} failed with following reason:'.format(self.cluster.id)
             logger.exception(msg)
             return {}
-        state = STATE_MAP.get(response.provisioning_state, config.get('CLUSTER_UNKNOWN_STATE'))
+        state = STATE_MAP.get(response.provisioning_state, kqueen_config.get('CLUSTER_UNKNOWN_STATE'))
 
         key = 'cluster-{}-{}'.format(self.name, self.cluster.id)
         cluster = {
@@ -297,17 +296,17 @@ class AksEngine(BaseEngine):
                                                       tenant=kwargs.get('tenant'))
         except AuthenticationError:
             logger.exception('Invalid credentials for {} Azure Provisioner'.format(cls.name))
-            return config.get('PROVISIONER_ERROR_STATE')
+            return kqueen_config.get('PROVISIONER_ERROR_STATE')
         except Exception:
             logger.exception('{} Azure Provisioner validation failed.'.format(cls.name))
-            return config.get('PROVISIONER_UNKNOWN_STATE')
+            return kqueen_config.get('PROVISIONER_UNKNOWN_STATE')
         client = ContainerServiceClient(credentials, kwargs.get('subscription_id'))
         try:
             list(client.managed_clusters.list_by_resource_group(kwargs.get('resource_group_name')))
         except CloudError as e:
             logger.exception('Invalid parameters for {} Azure Provisioner: {}'.format(cls.name, e.message))
-            return config.get('PROVISIONER_ERROR_STATE')
+            return kqueen_config.get('PROVISIONER_ERROR_STATE')
         except Exception:
             logger.exception('{} Azure Provisioner validation failed.'.format(cls.name))
-            return config.get('PROVISIONER_UNKNOWN_STATE')
-        return config.get('PROVISIONER_OK_STATE')
+            return kqueen_config.get('PROVISIONER_UNKNOWN_STATE')
+        return kqueen_config.get('PROVISIONER_OK_STATE')

--- a/kqueen/engines/base.py
+++ b/kqueen/engines/base.py
@@ -1,8 +1,6 @@
-from kqueen.config import current_config
-
+from kqueen.config.utils import kqueen_config
 import logging
 
-config = current_config()
 logger = logging.getLogger('kqueen_api')
 
 
@@ -214,4 +212,4 @@ class BaseEngine:
         Returns:
             str: Return status of engine, should use statuses from ``app.config``
         """
-        return config.get('PROVISIONER_OK_STATE')
+        return kqueen_config.get('PROVISIONER_OK_STATE')

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -1,5 +1,6 @@
+from kqueen.config.utils import kqueen_config
+
 from google.oauth2 import service_account
-from kqueen.config import current_config
 from kqueen.engines.base import BaseEngine
 
 import googleapiclient.discovery
@@ -7,14 +8,13 @@ import logging
 import requests
 
 logger = logging.getLogger('kqueen_api')
-config = current_config()
 
 
 STATE_MAP = {
-    'PROVISIONING': config.get('CLUSTER_PROVISIONING_STATE'),
-    'RUNNING': config.get('CLUSTER_OK_STATE'),
-    'STOPPING': config.get('CLUSTER_DEPROVISIONING_STATE'),
-    'RECONCILING': config.get('CLUSTER_RESIZING_STATE')
+    'PROVISIONING': kqueen_config.get('CLUSTER_PROVISIONING_STATE'),
+    'RUNNING': kqueen_config.get('CLUSTER_OK_STATE'),
+    'STOPPING': kqueen_config.get('CLUSTER_DEPROVISIONING_STATE'),
+    'RECONCILING': kqueen_config.get('CLUSTER_RESIZING_STATE')
 }
 
 
@@ -264,7 +264,7 @@ class GceEngine(BaseEngine):
             logger.exception(msg)
             return {}
 
-        state = STATE_MAP.get(response['status'], config.get('CLUSTER_UNKNOWN_STATE'))
+        state = STATE_MAP.get(response['status'], kqueen_config.get('CLUSTER_UNKNOWN_STATE'))
 
         key = 'cluster-{}-{}'.format(self.name, self.cluster_id)
         cluster = {
@@ -295,7 +295,7 @@ class GceEngine(BaseEngine):
         if clusters:
             cl = []
             for cluster in clusters:
-                state = STATE_MAP.get(cluster['status'], config.get('CLUSTER_UNKNOWN_STATE'))
+                state = STATE_MAP.get(cluster['status'], kqueen_config.get('CLUSTER_UNKNOWN_STATE'))
                 key = 'cluster-{}-{}'.format(cluster['name'], self.cluster_id or None)
                 item = {
                     'key': key,
@@ -331,9 +331,9 @@ class GceEngine(BaseEngine):
             except Exception as e:
                 msg = 'Failed to discover GCE project. Check that credentials is valid. Error:'
                 logger.exception(msg)
-                return config.get('PROVISIONER_UNKNOWN_STATE')
-            status = config.get('PROVISIONER_OK_STATE')
+                return kqueen_config.get('PROVISIONER_UNKNOWN_STATE')
+            status = kqueen_config.get('PROVISIONER_OK_STATE')
         else:
-            status = config.get('PROVISIONER_ERROR_STATE')
+            status = kqueen_config.get('PROVISIONER_ERROR_STATE')
 
         return status

--- a/kqueen/engines/manual.py
+++ b/kqueen/engines/manual.py
@@ -1,11 +1,10 @@
+from kqueen.config.utils import kqueen_config
 from .base import BaseEngine
-from kqueen.config import current_config
 from kqueen.kubeapi import KubernetesAPI
 
 import logging
 
 logger = logging.getLogger('kqueen_api')
-config = current_config()
 
 
 class ManualEngine(BaseEngine):
@@ -50,8 +49,8 @@ class ManualEngine(BaseEngine):
         except Exception as e:
             msg = 'Fetching data from backend for cluster {} failed with following reason:'.format(self.cluster.id)
             logger.exception(msg)
-            return {'state': config.get('CLUSTER_ERROR_STATE')}
-        return {'state': config.get('CLUSTER_OK_STATE')}
+            return {'state': kqueen_config.get('CLUSTER_ERROR_STATE')}
+        return {'state': kqueen_config.get('CLUSTER_OK_STATE')}
 
     def provision(self):
         """
@@ -62,7 +61,7 @@ class ManualEngine(BaseEngine):
         Implementation of :func:`~kqueen.engines.base.BaseEngine.provision`
         """
 
-        self.cluster.state = config.get('CLUSTER_OK_STATE')
+        self.cluster.state = kqueen_config.get('CLUSTER_OK_STATE')
         self.cluster.save()
 
         return True, None
@@ -98,7 +97,7 @@ class ManualEngine(BaseEngine):
         return {
             'response': 0,
             'progress': 100,
-            'result': config.get('CLUSTER_OK_STATE'),
+            'result': kqueen_config.get('CLUSTER_OK_STATE'),
         }
 
     @classmethod
@@ -107,4 +106,4 @@ class ManualEngine(BaseEngine):
 
         Implementation of :func:`~kqueen.engines.base.BaseEngine.engine_status`
         """
-        return config.get('PROVISIONER_OK_STATE')
+        return kqueen_config.get('PROVISIONER_OK_STATE')

--- a/kqueen/engines/test_manual.py
+++ b/kqueen/engines/test_manual.py
@@ -1,6 +1,6 @@
+from kqueen.config.utils import kqueen_config
 from .manual import ManualEngine
 from flask import url_for
-from kqueen.config import current_config
 from kqueen.conftest import auth_header
 from kqueen.conftest import user
 from kqueen.models import Cluster
@@ -10,7 +10,6 @@ import json
 import pytest
 import yaml
 
-config = current_config()
 KUBECONFIG = yaml.load(open('kubeconfig_localhost', 'r').read())
 CLUSTER_METADATA = {
     'minion_count': 10,
@@ -35,7 +34,7 @@ class ManualEngineBase:
         }
 
         prov = Provisioner(_user.namespace, **create_kwargs_provisioner)
-        prov.state = config.get('PROVISIONER_OK_STATE')
+        prov.state = kqueen_config.get('PROVISIONER_OK_STATE')
         prov.save(check_status=False)
 
         self.create_kwargs_cluster = {

--- a/kqueen/gunicorn.py
+++ b/kqueen/gunicorn.py
@@ -1,10 +1,10 @@
-from kqueen.config import current_config
+from kqueen.config.utils import kqueen_config
 from prometheus_client import multiprocess
 
 import multiprocessing
 import os
 
-app_config = current_config()
+app_config = kqueen_config
 
 bind = "{host}:{port}".format(
     host=app_config.get('KQUEEN_HOST'),

--- a/kqueen/server.py
+++ b/kqueen/server.py
@@ -2,7 +2,7 @@ from .auth import authenticate
 from .auth import identity
 from .blueprints.api.views import api
 from .blueprints.metrics.views import metrics
-from .config import current_config
+from .config.utils import kqueen_config
 from .exceptions import ImproperlyConfigured
 from .middleware import setup_metrics
 from .serializers import KqueenJSONEncoder
@@ -15,9 +15,9 @@ from werkzeug.contrib.cache import SimpleCache
 
 import logging
 
+
 # Logging configuration
-config = current_config(config_file=None)
-setup_logging(config.get('LOG_CONFIG'), config.get('DEBUG'))
+setup_logging(kqueen_config.get('LOG_CONFIG'), kqueen_config.get('DEBUG'))
 logger = logging.getLogger('kqueen_api')
 
 cache = SimpleCache()
@@ -42,14 +42,14 @@ def create_app(config_file=None):
     app.register_blueprint(swaggerui_blueprint, url_prefix=swagger_url)
 
     # load configuration
-    config = current_config(config_file)
+    config = config_file or kqueen_config
     config.setup_policies()
 
     secret_key = config.get('SECRET_KEY')
     if not secret_key or len(secret_key) < 16:
         raise ImproperlyConfigured('The SECRET_KEY must be set and longer than 16 chars.')
 
-    app.config.from_mapping(config.to_dict())
+    app.config.from_mapping(kqueen_config.to_dict())
 
     # setup database
     app.db = EtcdBackend()

--- a/kqueen/storages/etcd.py
+++ b/kqueen/storages/etcd.py
@@ -1,3 +1,4 @@
+from kqueen.config.utils import kqueen_config
 from .exceptions import BackendError
 from .exceptions import FieldError
 from Crypto import Random
@@ -5,7 +6,6 @@ from Crypto.Cipher import AES
 from datetime import datetime
 from dateutil.parser import parse as du_parse
 from flask import current_app
-from kqueen.config import current_config
 
 import base64
 import etcd
@@ -20,13 +20,12 @@ logger = logging.getLogger('kqueen_api')
 
 class EtcdBackend:
     def __init__(self, **kwargs):
-        config = current_config()
 
         self.client = etcd.Client(
-            host=config.get('ETCD_HOST', 'localhost'),
-            port=int(config.get('ETCD_PORT', 4001)),
+            host=kqueen_config.get('ETCD_HOST', 'localhost'),
+            port=int(kqueen_config.get('ETCD_PORT', 4001)),
         )
-        self.prefix = '{}/obj/'.format(config.get('ETCD_PREFIX', '/kqueen'))
+        self.prefix = '{}/obj/'.format(kqueen_config.get('ETCD_PREFIX', '/kqueen'))
 
 
 class Field:
@@ -126,8 +125,7 @@ class Field:
         """
 
         # check for key
-        config = current_config()
-        key = config.get('SECRET_KEY')
+        key = kqueen_config.get('SECRET_KEY')
 
         if key is None:
             raise Exception('Missing SECRET_KEY')

--- a/kqueen/tests/test_models.py
+++ b/kqueen/tests/test_models.py
@@ -1,6 +1,6 @@
+from kqueen.config.utils import kqueen_config
 from datetime import datetime
 from datetime import timedelta
-from kqueen.config import current_config
 from kqueen.engines import __all__ as all_engines
 from kqueen.engines import ManualEngine
 from kqueen.models import Cluster
@@ -11,8 +11,6 @@ from kqueen.storages.etcd import Model
 import pytest
 import subprocess
 import yaml
-
-config = current_config()
 
 
 class TestModelMethods:
@@ -211,7 +209,7 @@ class TestClusterState:
     @pytest.fixture(autouse=True)
     def prepare(self, cluster, monkeypatch):
         def fake_cluster_get(self):
-            return {'state': config.get('CLUSTER_PROVISIONING_STATE')}
+            return {'state': kqueen_config.get('CLUSTER_PROVISIONING_STATE')}
 
         monkeypatch.setattr(ManualEngine, 'cluster_get', fake_cluster_get)
 
@@ -225,4 +223,4 @@ class TestClusterState:
         cluster_state = self.cluster.get_state()
         print(self.cluster.get_state())
 
-        assert cluster_state == config.get('CLUSTER_ERROR_STATE')
+        assert cluster_state == kqueen_config.get('CLUSTER_ERROR_STATE')


### PR DESCRIPTION
- To avoid multiple config calls and redundant logging
- To provide visibility of using configuration in docker container
- To avoid issues with overriding defined config in backend