### PR TITLE
Refactor Ldap Search-verify mechanism

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -10,6 +10,8 @@ services:
       KQUEEN_CONFIG_FILE: config/demo.py
       KQUEEN_DEBUG: 'False'
       KQUEEN_LDAP_URI: 'ldap://ldap'
+      KQUEEN_LDAP_DN: 'cn=admin,dc=example,dc=org'
+      KQUEEN_LDAP_PASSWORD: 'heslo123'
       KQUEEN_AUTH_MODULES: 'local,ldap'
       KQUEEN_ETCD_HOST: etcd
       KQUEEN_SECRET_KEY: 'SecretSecretSecret123'

--- a/docs/kqueen.rst
+++ b/docs/kqueen.rst
@@ -277,6 +277,8 @@ To set up the LDAP server
    .. code-block:: yaml
 
       KQUEEN_LDAP_URI: 'ldap://ldap'
+      KQUEEN_LDAP_DN: 'cn=admin,dc=example,dc=org'
+      KQUEEN_LDAP_PASSWORD: 'secret'
       KQUEEN_AUTH_MODULES: 'local,ldap'
       KQUEENUI_LDAP_AUTH_NOTIFY: 'False'
 
@@ -291,15 +293,17 @@ To set up the LDAP server
 
 .. note::
 
+   ``KQUEEN_LDAP_DN``/ ``KQUEEN_LDAP_PASSWORD`` User credentials with read-only access for Ldap-search
+
+.. note::
+
    In case of using external LDAP server, skip steps 1 and 2.
 
-Once done, you should be able to invite members through LDAP. Define username for new member according to following scheme:
+Once done, you should be able to invite members through LDAP. Define ``cn`` as username for new member:
 
-.. code-block:: text
+.. note::
 
-   <<cn>>@<<dc>>.<<dc>>
-
-   For example user ``kqueen@mirantis.com`` should be equal to LDAP entry: ``cn=kqueen, dc=mirantis, dc=com``
+   'dc' for invited users equal to predefined in ``KQUEEN_LDAP_DN``
 
 Users with superadmin rights can also manage member roles.
 

--- a/kqueen/auth/common.py
+++ b/kqueen/auth/common.py
@@ -28,7 +28,9 @@ AUTH_MODULES = {
     "ldap": {
         "engine": "LDAPAuth",
         "parameters": {
-            "uri": config.get('LDAP_URI')
+            "uri": config.get('LDAP_URI'),
+            "admin_dn": config.get('LDAP_DN'),
+            "password": config.get('LDAP_PASSWORD')
         }
     },
     "local": {
@@ -96,10 +98,9 @@ def authenticate(username, password):
     user = username_table.get(username)
 
     if user:
+        user.metadata = user.metadata or {}
         given_password = password.encode('utf-8')
-
         logger.debug("User {} will be authenticated using {}".format(username, user.auth))
-
         auth_instance = get_auth_instance(user.auth)
 
         try:

--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -51,6 +51,9 @@ class BaseConfig:
 
     # Auth config
     LDAP_URI = 'ldap://127.0.0.1'
+    # Creds for Kqueen Read-only user
+    LDAP_DN = 'cn=admin,dc=example,dc=org'
+    LDAP_PASSWORD = 'heslo123'
 
     @classmethod
     def get(cls, name, default=None):

--- a/kqueen/config/demo.py
+++ b/kqueen/config/demo.py
@@ -30,3 +30,6 @@ class Config(BaseConfig):
 
     # Ldap config
     LDAP_URI = 'ldap://127.0.0.1'
+    # Creds for Kqueen Read-only user
+    LDAP_DN = 'cn=admin,dc=example,dc=org'
+    LDAP_PASSWORD = 'heslo123'

--- a/kqueen/config/prod.py
+++ b/kqueen/config/prod.py
@@ -12,3 +12,6 @@ class Config(BaseConfig):
 
     # Ldap config
     LDAP_URI = 'ldap://127.0.0.1'
+    # Creds for Kqueen Read-only user
+    LDAP_DN = 'cn=admin,dc=example,dc=org'
+    LDAP_PASSWORD = 'heslo123'

--- a/kqueen/config/test.py
+++ b/kqueen/config/test.py
@@ -34,7 +34,7 @@ class Config(BaseConfig):
     AUTH_MODULES = 'local,ldap'
 
     # Ldap config
-    LDAP_URI = 'ldap://ldap'
+    LDAP_URI = 'ldap://127.0.0.1'
     # Creds for Kqueen Read-only user
     LDAP_DN = 'cn=admin,dc=example,dc=org'
     LDAP_PASSWORD = 'heslo123'

--- a/kqueen/config/test.py
+++ b/kqueen/config/test.py
@@ -35,3 +35,6 @@ class Config(BaseConfig):
 
     # Ldap config
     LDAP_URI = 'ldap://ldap'
+    # Creds for Kqueen Read-only user
+    LDAP_DN = 'cn=admin,dc=example,dc=org'
+    LDAP_PASSWORD = 'heslo123'


### PR DESCRIPTION
    Refactor Ldap Search-verify mechanism

    - Search by provided dn segments to get full dn
    - possibility of adding full dn to user metadata
    - logging
    - docs updated
    - env variables for read-only user for Ldap-search

    Ldap-user adding scheme will be:

    UI:
    invite ldap user with cn 'kqueen'

    API:
    1. get dc's from predefined kqueen-ldap user
    2. search in all OU by cn and dc's and paste all matched cases into list

    UI:
    try to enter login and text 'password'

    API:
    3. try to bind_s with list of mathced_dn and provided 'password'
    4. in case of success, store valid full-dn into user-metadata, and re-use it without search-duplicating

    P.s. afaik in LDAP user 'CN' should be absolutely equal.Its absolutely independent of OU,Posix groups.
    Ldap doesnot allow to create users in diff groups with equal 'CN'. So , it's avoid us of several searching problems
PAY ATTENTION:
This PR depends on UI changes related to Invite form improvement @katyafervent 