### PR TITLE
Calico networking support for GKE

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,15 +1,14 @@
 version: '3.2'
 services:
   api:
-#    image: kqueen/api:v0.18
-    image: vnaumov/kqueen-api:mk1
+    image: kqueen/api:v0.18
     ports:
       - 127.0.0.1:5000:5000
     depends_on:
       - etcd
     environment:
       KQUEEN_CONFIG_FILE: config/demo.py
-      KQUEEN_DEBUG: 'True'
+      KQUEEN_DEBUG: 'False'
       KQUEEN_LDAP_URI: 'ldap://ldap'
       KQUEEN_LDAP_DN: 'cn=admin,dc=example,dc=org'
       KQUEEN_LDAP_PASSWORD: 'heslo123'
@@ -24,16 +23,14 @@ services:
     extra_hosts:
       - "ci.mcp.mirantis.net:172.16.48.254"
   ui:
-#    image: kqueen/ui:v0.9
-#    image: vnaumov/kqueen-ui:mk2
-    image: vnaumov/kqueen-ui:mk1
+    image: kqueen/ui:v0.9
     ports:
       - 127.0.0.1:5080:5080
     depends_on:
       - api
     environment:
       KQUEEN_UI_CONFIG_FILE: config/demo.py
-      KQUEENUI_DEBUG: 'True'
+      KQUEENUI_DEBUG: 'False'
       KQUEENUI_SECRET_KEY: 'SecretSecretSecret123'
       KQUEENUI_KQUEEN_API_URL: http://api:5000/api/v1/
       KQUEENUI_KQUEEN_AUTH_URL: http://api:5000/api/v1/auth

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,14 +1,15 @@
 version: '3.2'
 services:
   api:
-    image: kqueen/api:v0.18
+#    image: kqueen/api:v0.18
+    image: vnaumov/kqueen-api:mk1
     ports:
       - 127.0.0.1:5000:5000
     depends_on:
       - etcd
     environment:
       KQUEEN_CONFIG_FILE: config/demo.py
-      KQUEEN_DEBUG: 'False'
+      KQUEEN_DEBUG: 'True'
       KQUEEN_LDAP_URI: 'ldap://ldap'
       KQUEEN_LDAP_DN: 'cn=admin,dc=example,dc=org'
       KQUEEN_LDAP_PASSWORD: 'heslo123'
@@ -23,14 +24,16 @@ services:
     extra_hosts:
       - "ci.mcp.mirantis.net:172.16.48.254"
   ui:
-    image: kqueen/ui:v0.8
+#    image: kqueen/ui:v0.9
+#    image: vnaumov/kqueen-ui:mk2
+    image: vnaumov/kqueen-ui:mk1
     ports:
       - 127.0.0.1:5080:5080
     depends_on:
       - api
     environment:
       KQUEEN_UI_CONFIG_FILE: config/demo.py
-      KQUEENUI_DEBUG: 'False'
+      KQUEENUI_DEBUG: 'True'
       KQUEENUI_SECRET_KEY: 'SecretSecretSecret123'
       KQUEENUI_KQUEEN_API_URL: http://api:5000/api/v1/
       KQUEENUI_KQUEEN_AUTH_URL: http://api:5000/api/v1/auth

--- a/kqueen/blueprints/api/tests.py
+++ b/kqueen/blueprints/api/tests.py
@@ -50,7 +50,7 @@ def test_root(client):
     test_auth_header = AuthHeader()
     response = client.get(url_for('api.index'), headers=test_auth_header.get(client))
 
-    assert response.json == {'response': 'Gutten tag!'}
+    assert response.json == {'response': 'Kqueen ready!'}
     test_auth_header.destroy()
 
 

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -65,7 +65,7 @@ def not_implemented(error):
 @api.route('/')
 @api.route('/health')
 def index():
-    return jsonify({'response': 'Gutten tag!'})
+    return jsonify({'response': 'Kqueen ready!'})
 
 
 # Clusters

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -221,6 +221,30 @@ def cluster_resize(pk):
     return jsonify(output)
 
 
+@api.route('/clusters/<uuid:pk>/set_network_policy', methods=['PATCH'])
+@jwt_required()
+def cluster_set_network_policy(pk):
+    obj = get_object(Cluster, pk, current_identity)
+
+    if not request.json:
+        abort(400, description='JSON data expected')
+
+    data = request.json
+    if not all(k in data for k in ('provider', 'enabled')):
+        msg = 'Failed to get network policy configuration'
+        logger.error(msg)
+        abort(400, description=msg)
+
+    res_status, res_msg = obj.engine.set_network_policy(data['provider'], data['enabled'])
+    if not res_status:
+        logger.error('Setting network policy failed: {}'.format(res_msg))
+        abort(500, description=res_msg)
+
+    # get object with updated metadata
+    output = obj.engine.cluster
+    return jsonify(output)
+
+
 # Provisioners
 class ListProvisioners(ListView):
     object_class = Provisioner

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -231,7 +231,7 @@ def cluster_set_network_policy(pk):
 
     data = request.json
     if not all(k in data for k in ('provider', 'enabled')):
-        msg = 'Failed to get network policy configuration'
+        msg = 'Incorrect network policy configuration {}'.format(data)
         logger.error(msg)
         abort(400, description=msg)
 

--- a/kqueen/config/base.py
+++ b/kqueen/config/base.py
@@ -29,7 +29,7 @@ class BaseConfig:
     CLUSTER_OK_STATE = 'OK'
     CLUSTER_PROVISIONING_STATE = 'Deploying'
     CLUSTER_DEPROVISIONING_STATE = 'Destroying'
-    CLUSTER_RESIZING_STATE = 'Resizing'
+    CLUSTER_UPDATING_STATE = 'Updating'
     CLUSTER_UNKNOWN_STATE = 'Unknown'
 
     CLUSTER_STATE_ON_LIST = True

--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -20,7 +20,7 @@ STATE_MAP = {
     'Succeeded': config.get('CLUSTER_OK_STATE'),
     'Deleting': config.get('CLUSTER_DEPROVISIONING_STATE'),
     'Failed': config.get('CLUSTER_ERROR_STATE'),
-    'Updating': config.get('CLUSTER_RESIZING_STATE')
+    'Updating': config.get('CLUSTER_UPDATING_STATE')
 }
 
 

--- a/kqueen/engines/base.py
+++ b/kqueen/engines/base.py
@@ -164,6 +164,21 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    def set_network_policy(self, network_provider, enabled):
+        """Set specific network policy to the cluster related to this engine instance.
+
+        Args:
+            network_provider(str):           Name of supported network provider/addon
+            enabled(bool):                   Enable/Disable policy
+
+        Returns:
+            tuple: First item is bool (success/failure), second item is error, can be None::
+
+                (True, None)                            # successful policy update
+                (False, 'error_message')                # failed policy update, error description
+        """
+        raise NotImplementedError
+
     def get_kubeconfig(self):
         """Get kubeconfig of the cluster related to this engine from backend.
 

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -106,7 +106,7 @@ class GceEngine(BaseEngine):
             'network_range': {
                 'type': 'text',
                 'label': 'Network range CIDR',
-                'order': 5,
+                'order': 4,
                 'placeholder': '10.0.0.0/14',
                 'validators': {
                     'required': False,
@@ -125,7 +125,7 @@ class GceEngine(BaseEngine):
                 ],
                 'default': 'PROVIDER_UNSPECIFIED',
                 'validators': {
-                    'required': True
+                    'required': False
                 },
                 'class_name': 'network-policy'
             }
@@ -320,10 +320,10 @@ class GceEngine(BaseEngine):
 
         logger.debug('Setting {} network policy to cluster {}...'.format(network_provider,
                                                                          self.cluster_id))
-        request = self.client.projects().zones().clusters().setNetworkPolicy(projectId=self.project,
-                                                                             zone=self.zone,
-                                                                             clusterId=self.cluster_id,
-                                                                             body=network_policy_body)
+        request = self.client.projects().zones().clusters().setNetworkPolicy(
+            projectId=self.project, zone=self.zone,
+            clusterId=self.cluster_id, body=network_policy_body)
+
         try:
             request.execute()
         except Exception as e:

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -35,6 +35,7 @@ class GceEngine(BaseEngine):
             'service_account_info': {
                 'type': 'json_file',
                 'label': 'Service Account File (JSON)',
+                'order': 0,
                 'validators': {
                     'required': True,
                     'jsonfile': [
@@ -52,7 +53,9 @@ class GceEngine(BaseEngine):
             'node_count': {
                 'type': 'integer',
                 'label': 'Node Count',
+                'order': 1,
                 'default': 1,
+                'class_name': 'gke_node_count',
                 'validators': {
                     'required': True,
                     'min': 1,
@@ -62,6 +65,7 @@ class GceEngine(BaseEngine):
             'zone': {
                 'type': 'select',
                 'label': 'Zone',
+                'order': 2,
                 'choices': [
                     ('us-central1-a', 'US - Central 1 - A'),
                     ('us-west1-a', 'US - West 1 - A'),
@@ -85,6 +89,7 @@ class GceEngine(BaseEngine):
             'machine_type': {
                 'type': 'select',
                 'label': 'Machine Type',
+                'order': 3,
                 'choices': [
                     ('n1-standard-1', 'Standart: 1 vCPU, 3.75 GB RAM'),
                     ('n1-standard-2', 'Standart: 2 vCPU, 7.5 GB RAM'),
@@ -97,6 +102,29 @@ class GceEngine(BaseEngine):
                 'validators': {
                     'required': True
                 }
+            },
+            'network_range': {
+                # TODO set CIDR validators, decide class naming after UI changes
+                'type': 'text',
+                'label': 'Network range CIDR',
+                'order': 4,
+                'class_name': 'gke_network_range',
+                'validators': {
+                    'required': False,
+                }
+            },
+            'network_policy': {
+                'type': 'select',
+                'label': 'Network Policy',
+                'order': 5,
+                'choices': [
+                    (None, '(None)'),
+                    ('CALICO', 'Calico')
+                ],
+                'validators': {
+                    'required': True
+                },
+                'class_name': 'network-policy'
             }
         }
     }
@@ -118,9 +146,22 @@ class GceEngine(BaseEngine):
                 'initialNodeCount': kwargs.get('node_count', 1),
                 'nodeConfig': {
                     'machineType': kwargs.get('machine_type', 'n1-standard-1')
+                },
+                'addonsConfig': {},
+                'clusterIpv4Cidr': kwargs.get('network_range', ''),
+                'networkPolicy': {
+                    'provider': kwargs['network_policy'].get('provider', 'PROVIDER_UNSPECIFIED'),
+                    'enabled': bool(kwargs.get('network_policy', False))
                 }
             }
         }
+        if self.cluster_config['cluster']['networkPolicy']['enabled'] is True:
+            logger.debug('Network addon for GKE enabled')
+            self.cluster_config = self._set_addon_config(cluster_config=self.cluster_config,
+                                                         addon='networkPolicyConfig',
+                                                         disabled=False)
+
+        logger.debug('GKE cluster configuration: {}'.format(self.cluster_config))
         self.client = self._get_client()
         # Cache settings
         self.cache_timeout = 5 * 60
@@ -136,17 +177,55 @@ class GceEngine(BaseEngine):
 
         return client
 
+    def _set_addon_config(self, cluster_config, addon, disabled):
+        """Set addon configutation to the cluster.
+
+        Args:
+            cluster_config(dict): Current cluster configuration
+            addon(str):           Name of supported addon
+            disabled(bool):       Enable/Disable addon
+
+        Returns:
+            dict:                 Updated cluster configuration
+
+        """
+        addons_body = {
+            addon: {
+                'disabled': disabled
+            }
+        }
+        addons_config = cluster_config['cluster'].get('addonsConfig', {})
+        addons_config[addon] = addons_body[addon]
+        logger.debug('Setting {} addon in cluster_config {}'.format(addon, cluster_config))
+
+        return cluster_config
+
     def provision(self, **kwargs):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.provision`
         """
+
+        request = self.client.projects().zones().clusters().create(projectId=self.project,
+                                                                   zone=self.zone,
+                                                                   body=self.cluster_config)
         try:
-            self.client.projects().zones().clusters().create(projectId=self.project, zone=self.zone, body=self.cluster_config).execute()
+            request.execute()
             # TODO: check if provisioning response is healthy
         except Exception as e:
-            msg = 'Creating cluster {} failed with following reason:'.format(self.cluster_id)
+            msg = 'Creating cluster {} failed with the following reason: {}'.format(self.cluster_id,
+                                                                                    e)
             logger.exception(msg)
             return False, msg
+
+        current_policy = self.cluster_config['cluster']['networkPolicy']
+        meta = self.cluster.metadata.get('network_policy', {})
+
+        if current_policy['provider'] is not None:
+            meta['provider'] = current_policy['provider']
+            meta['enabled'] = current_policy['enabled']
+            logger.critical('Provisioning cluster {} started,\
+                            updating metadata...{}'.format(self.cluster_id, meta))
+            self.cluster.save()
 
         return True, None
 
@@ -158,18 +237,31 @@ class GceEngine(BaseEngine):
         result, error = super(GceEngine, self).deprovision(**kwargs)
         if result:
             return result, error
-
+        request = self.client.projects().zones().clusters().delete(projectId=self.project,
+                                                                   zone=self.zone,
+                                                                   clusterId=self.cluster_id)
         try:
-            self.client.projects().zones().clusters().delete(projectId=self.project, zone=self.zone, clusterId=self.cluster_id).execute()
+            request.execute()
             # TODO: check if provisioning response is healthy
         except Exception as e:
-            msg = 'Deleting cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
+            msg = 'Deleting cluster {} failed with following reason: {}'.format(self.cluster_id,
+                                                                                repr(e))
             logger.exception(msg)
             return False, msg
 
         return True, None
 
     def resize(self, node_count, **kwargs):
+
+        if int(node_count) < 2 and \
+           self.cluster_config['cluster']['networkPolicy']['enabled'] is True:
+            msg = 'Resizing cluster {} denied. The minimum size cluster to run \
+                   network policy enforcement is 2 n1-standard-1 instances.\
+                   Otherwise, turn off network policy before resizing.'\
+                   .format(self.cluster_id)
+            logger.error(msg)
+            return False, msg
+
         request = self.client.projects().zones().clusters().nodePools().setSize(
             nodePoolId='default-pool',
             clusterId=self.cluster_id,
@@ -180,11 +272,76 @@ class GceEngine(BaseEngine):
         try:
             request.execute()
         except Exception as e:
-            msg = 'Resizing cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
+            msg = 'Resizing cluster {} failed with the following reason: {}'\
+                  .format(self.cluster_id, repr(e))
             logger.exception(msg)
             return False, msg
 
         self.cluster.metadata['node_count'] = node_count
+        self.cluster.save()
+
+        return True, None
+
+    def set_network_policy(self, network_provider='CALICO', enabled=False, **kwargs):
+        """
+        Implementation of :func:`~kqueen.engines.base.BaseEngine.deprovision`
+        """
+        unsupported_instances = ['g1-small', 'f1-micro']
+        network_policy_body = {
+            'networkPolicy': {
+                'provider': network_provider,
+                'enabled': enabled
+            }
+        }
+
+        m_type = self.cluster_config['cluster']['nodeConfig']['machineType']
+        current_node_count = int(self.cluster_config['cluster'].get('initialNodeCount', 1))
+
+        if current_node_count < 2 or m_type in unsupported_instances:
+            msg = 'Setting {} Network Policy for the cluster {} denied due to \
+                   unsupported configuration. The recommended minimum size \
+                   cluster to run network policy enforcement is 3 \
+                   n1-standard-1 instances'.format(network_provider,
+                                                   self.cluster_id)
+            logger.error(msg)
+            return False, msg
+
+        logger.debug('Required Node amount for Network Policy is 2, current node amount: {}'
+                     .format(current_node_count))
+        network_addon = self.cluster_config['cluster']['addonsConfig'].get('networkPolicyConfig',
+                                                                           {})
+        logger.debug('Enabled Network addon: {}'.format(network_addon))
+
+        if network_addon.get('disabled', True) is True:
+            msg = 'Setting {} Network Policy for the cluster {} denied due to \
+                   disabled Network Policy addon. Recreate stack with enabled \
+                   Network Policy'.format(network_provider, self.cluster_id)
+            logger.error(msg)
+            return False, msg
+
+        logger.debug('Setting {} network policy to cluster {}...'.format(network_provider,
+                                                                         self.cluster_id))
+        request = self.client.projects().zones().clusters().setNetworkPolicy(projectId=self.project,
+                                                                             zone=self.zone,
+                                                                             clusterId=self.cluster_id,
+                                                                             body=network_policy_body)
+        try:
+            request.execute()
+        except Exception as e:
+            msg = 'Setting {} Network Policy for cluster {} failed with the following reason: {}'\
+                .format(network_provider, self.cluster_id, e)
+            logger.exception(msg)
+            return False, msg
+
+        logger.debug('Setting {} network policy to cluster {} passed successfully,\
+                     saving metadata...'.format(network_provider, self.cluster_id))
+
+        meta = self.cluster.metadata.get('network_policy', {})
+        logger.critical('current NETMETA..{}'.format(meta))
+        meta['provider'] = network_provider
+        meta['enabled'] = enabled
+        logger.critical(' Updating NETWORKPOLICY for cluster {} started,\
+                        saving metadata...{}'.format(self.cluster_id, self.cluster.metadata['network_policy']))
         self.cluster.save()
 
         return True, None
@@ -194,7 +351,10 @@ class GceEngine(BaseEngine):
         Implementation of :func:`~kqueen.engines.base.BaseEngine.get_kubeconfig`
         """
         if not self.cluster.kubeconfig:
-            cluster = self.client.projects().zones().clusters().get(projectId=self.project, zone=self.zone, clusterId=self.cluster_id).execute()
+            request = self.client.projects().zones().clusters().get(projectId=self.project,
+                                                                    zone=self.zone,
+                                                                    clusterId=self.cluster_id)
+            cluster = request.execute()
 
             kubeconfig = {}
 
@@ -260,7 +420,8 @@ class GceEngine(BaseEngine):
         try:
             response = request.execute()
         except Exception as e:
-            msg = 'Fetching data from backend for cluster {} failed with following reason: {}'.format(self.cluster_id, repr(e))
+            msg = 'Fetching data from backend for cluster {} failed with the following reason: {}'\
+                .format(self.cluster_id, repr(e))
             logger.exception(msg)
             return {}
 
@@ -280,14 +441,17 @@ class GceEngine(BaseEngine):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.cluster_list`
 
-        Get list of all clusters, owned by project, both kqueen managed and others in either the specified zone or all zones
+        Get list of all clusters, owned by project,
+        both kqueen managed and others in either the specified zone or all zones
         """
 
-        request = self.client.projects().zones().clusters().list(projectId=self.project, zone=self.zone)
+        request = self.client.projects().zones().clusters().list(projectId=self.project,
+                                                                 zone=self.zone)
         try:
             response = request.execute()
         except Exception as e:
-            msg = 'Fetching data from backend for GCE project {} failed with following reason:'.format(self.project_id)
+            msg = 'Fetching data from backend for GCE project {} failed with the following reason:'\
+                .format(self.project_id)
             logger.exception(msg)
             return []
 
@@ -326,8 +490,9 @@ class GceEngine(BaseEngine):
         response = requests.get(test_url, headers=headers)
 
         if response.status_code == 401:
+            request = client.projects().zones().clusters().list(projectId=project, zone=project_zone)
             try:
-                client.projects().zones().clusters().list(projectId=project, zone=project_zone).execute()
+                request.execute()
             except Exception as e:
                 msg = 'Failed to discover GCE project. Check that credentials is valid. Error:'
                 logger.exception(msg)

--- a/kqueen/engines/gce.py
+++ b/kqueen/engines/gce.py
@@ -14,7 +14,7 @@ STATE_MAP = {
     'PROVISIONING': config.get('CLUSTER_PROVISIONING_STATE'),
     'RUNNING': config.get('CLUSTER_OK_STATE'),
     'STOPPING': config.get('CLUSTER_DEPROVISIONING_STATE'),
-    'RECONCILING': config.get('CLUSTER_RESIZING_STATE')
+    'RECONCILING': config.get('CLUSTER_UPDATING_STATE')
 }
 
 
@@ -104,13 +104,15 @@ class GceEngine(BaseEngine):
                 }
             },
             'network_range': {
-                # TODO set CIDR validators, decide class naming after UI changes
                 'type': 'text',
                 'label': 'Network range CIDR',
-                'order': 4,
-                'class_name': 'gke_network_range',
+                'order': 5,
+                'placeholder': '10.0.0.0/14',
                 'validators': {
                     'required': False,
+                    'regexp': '(^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}'
+                              '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
+                              '(/([0-9]|[1-9][0-9]|2[0-4]))?$)?'
                 }
             },
             'network_policy': {
@@ -118,9 +120,10 @@ class GceEngine(BaseEngine):
                 'label': 'Network Policy',
                 'order': 5,
                 'choices': [
-                    (None, '(None)'),
+                    ('PROVIDER_UNSPECIFIED', '(None)'),
                     ('CALICO', 'Calico')
                 ],
+                'default': 'PROVIDER_UNSPECIFIED',
                 'validators': {
                     'required': True
                 },
@@ -140,6 +143,19 @@ class GceEngine(BaseEngine):
         self.project = self.service_account_info.get('project_id', '')
         self.zone = kwargs.get('zone', '-')
         self.cluster_id = 'a' + self.cluster.id.replace('-', '')
+
+        # Generate metadata for Network Policies if empty
+        if not isinstance(cluster.metadata.get('network_policy'), dict):
+            network_provider = kwargs.get('network_policy', 'PROVIDER_UNSPECIFIED')
+            self.cluster.metadata['network_policy'] = {
+                'provider': network_provider,
+                'enabled': network_provider != 'PROVIDER_UNSPECIFIED'
+            }
+            logger.debug('Generate metadata for network policies: {}'
+                         .format(self.cluster.metadata['network_policy']))
+            self.cluster.save()
+
+        meta = self.cluster.metadata
         self.cluster_config = {
             'cluster': {
                 'name': self.cluster_id,
@@ -147,19 +163,18 @@ class GceEngine(BaseEngine):
                 'nodeConfig': {
                     'machineType': kwargs.get('machine_type', 'n1-standard-1')
                 },
-                'addonsConfig': {},
+                'addonsConfig': {
+                    'networkPolicyConfig': {
+                        'disabled': meta['network_policy'].get('provider', 'PROVIDER_UNSPECIFIED') == 'PROVIDER_UNSPECIFIED'
+                    }
+                },
                 'clusterIpv4Cidr': kwargs.get('network_range', ''),
                 'networkPolicy': {
-                    'provider': kwargs['network_policy'].get('provider', 'PROVIDER_UNSPECIFIED'),
-                    'enabled': bool(kwargs.get('network_policy', False))
+                    'provider': meta['network_policy'].get('provider', 'PROVIDER_UNSPECIFIED'),
+                    'enabled': meta['network_policy'].get('enabled', False)
                 }
             }
         }
-        if self.cluster_config['cluster']['networkPolicy']['enabled'] is True:
-            logger.debug('Network addon for GKE enabled')
-            self.cluster_config = self._set_addon_config(cluster_config=self.cluster_config,
-                                                         addon='networkPolicyConfig',
-                                                         disabled=False)
 
         logger.debug('GKE cluster configuration: {}'.format(self.cluster_config))
         self.client = self._get_client()
@@ -177,29 +192,6 @@ class GceEngine(BaseEngine):
 
         return client
 
-    def _set_addon_config(self, cluster_config, addon, disabled):
-        """Set addon configutation to the cluster.
-
-        Args:
-            cluster_config(dict): Current cluster configuration
-            addon(str):           Name of supported addon
-            disabled(bool):       Enable/Disable addon
-
-        Returns:
-            dict:                 Updated cluster configuration
-
-        """
-        addons_body = {
-            addon: {
-                'disabled': disabled
-            }
-        }
-        addons_config = cluster_config['cluster'].get('addonsConfig', {})
-        addons_config[addon] = addons_body[addon]
-        logger.debug('Setting {} addon in cluster_config {}'.format(addon, cluster_config))
-
-        return cluster_config
-
     def provision(self, **kwargs):
         """
         Implementation of :func:`~kqueen.engines.base.BaseEngine.provision`
@@ -208,6 +200,16 @@ class GceEngine(BaseEngine):
         request = self.client.projects().zones().clusters().create(projectId=self.project,
                                                                    zone=self.zone,
                                                                    body=self.cluster_config)
+        cluster_config = self.cluster_config['cluster']
+        network_meta = self.cluster.metadata['network_policy']
+        if network_meta['provider'] == 'CALICO' and int(cluster_config['initialNodeCount']) < 2:
+            msg = 'Setting {} Network Policy for the cluster {} denied due to '\
+                  'unsupported configuration. The minimal size of the '\
+                  'cluster to run network policy enforcement is 2 '\
+                  'n1-standard-1 instances'.format(network_meta['provider'],
+                                                   self.cluster_id)
+            logger.error(msg)
+            return False, msg
         try:
             request.execute()
             # TODO: check if provisioning response is healthy
@@ -217,14 +219,11 @@ class GceEngine(BaseEngine):
             logger.exception(msg)
             return False, msg
 
-        current_policy = self.cluster_config['cluster']['networkPolicy']
-        meta = self.cluster.metadata.get('network_policy', {})
-
-        if current_policy['provider'] is not None:
-            meta['provider'] = current_policy['provider']
-            meta['enabled'] = current_policy['enabled']
-            logger.critical('Provisioning cluster {} started,\
-                            updating metadata...{}'.format(self.cluster_id, meta))
+        if cluster_config['networkPolicy']['provider'] != 'PROVIDER_UNSPECIFIED':
+            network_meta['provider'] = cluster_config['networkPolicy']['provider']
+            network_meta['enabled'] = cluster_config['networkPolicy']['enabled']
+            logger.debug('Provisioning cluster {} started, updating metadata...{}'
+                         .format(self.cluster_id, self.cluster.metadata))
             self.cluster.save()
 
         return True, None
@@ -337,11 +336,10 @@ class GceEngine(BaseEngine):
                      saving metadata...'.format(network_provider, self.cluster_id))
 
         meta = self.cluster.metadata.get('network_policy', {})
-        logger.critical('current NETMETA..{}'.format(meta))
         meta['provider'] = network_provider
         meta['enabled'] = enabled
-        logger.critical(' Updating NETWORKPOLICY for cluster {} started,\
-                        saving metadata...{}'.format(self.cluster_id, self.cluster.metadata['network_policy']))
+        logger.debug('Updating network policy for cluster {} started, saving metadata...{}'
+                     .format(self.cluster_id, self.cluster.metadata['network_policy']))
         self.cluster.save()
 
         return True, None


### PR DESCRIPTION
    use-cases:
    1) User deploy GKE cluster and enable CALICO network policy:
    - network addon enabled too , due dependencies
    - network policy enabled
    2) User wants to on/off Network policy on existing cluster:
    - cluster must be deployed like p.1 only, otherwise, user cannot manage policies
    =============
    network-range
    use-cases:
    1) User deploy GKE cluster and specify network range:
    -The IP address range of the container pods in this cluster, in CIDR notation (e.g. 10.96.0.0/14).
    Leave blank to have one automatically chosen or specify a /14 block in 10.0.0.0/8.

    P.s.
    - refactoring to associate 100-symbols raw
    - logging increased