### PR TITLE
Update docker-compose file version to latest (3.6)

### DIFF
--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 services:
   ldap:
     image: osixia/openldap

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 services:
   api:
     image: kqueen/api:v0.18

--- a/docker-compose.etcd-volume.yml
+++ b/docker-compose.etcd-volume.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 networks:
   default:
     driver: bridge

--- a/docker-compose.kubernetes.yml
+++ b/docker-compose.kubernetes.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 services:
   apiserver:
     image: gcr.io/google_containers/hyperkube-amd64:v1.9.0

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 services:
   etcd:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
In order to support latest docker-compose syntax, set latest possible version.
PR updates syntax files to 3.6 (later updated somehwre between 3.2 - 3.6)

Update:
as proved during CI, travis environment don't support yet prereqsites:
- docker-compose >= v1.20.x
- docker engine >= v18.02

follow-up updates will lower minor version to latest possible.