### PR TITLE
Calico aws

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,7 +1,8 @@
 version: '2'
 services:
   api:
-    image: kqueen/api:v0.18
+#    image: kqueen/api:v0.18
+    image: vnaumov/kqueen-api:mk2
     ports:
       - 127.0.0.1:5000:5000
     depends_on:


### PR DESCRIPTION
    WIP Define parameters  overriding for Jenkins

    Use cases:
    1) Calico managing in case of using mcp-job calico-ha-aws-k8s
    2) overriding parameters in case of any jenkins job

    From UI part:
    At least need to provide possibility of defining key(str):value(str) parameters
scheme = https://www.lucidchart.com/invitations/accept/6e2bbc84-a5df-43f9-8b21-2a5b754a57d8