### PR TITLE
Refactor demo OS-provisioner

### DIFF
--- a/docs/kqueen.rst
+++ b/docs/kqueen.rst
@@ -369,12 +369,17 @@ To provision a Kubernetes cluster using the Openstack Engine:
 #. Copy ``User Name``, ``Project Name``, ``Authentication URL``
 #. Navigate to ``Project`` -> ``Network`` -> ``Networking``
 #. Click on your Private Network, then click on a Subnet of your Private Network.
-#. Copy the ID of the Subnet and the Network ID
+#. Copy the ID of the Subnet and the Network ID.
 #. Navigate to ``Project`` -> ``Network`` -> ``Networking``
-#. Click on your Public Network, then copy the public network ID
+#. Click on your ``Public Network``, then copy the public network ID.
 #. Import into Glance the following image http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1801-01.qcow2
-#. Download the following heat template https://github.com/Mirantis/kqueen/prod/openstack/heat-templates/kubernetes.yaml
-#. Under the ``parameters:`` section replace the private_net_id, private_subnet_id and public_net_id default values with ones you copied.
+#. Navigate to ``Project`` -> ``Compute`` -> ``API Access`` tab and click ``Key Pairs``.
+#. Create key pair for k8s cluster.
+#. Download the following heat template https://github.com/Mirantis/kqueen/prod/openstack/heat-templates/kubernetes-cluster.yaml
+#. Open the heat template file for editing.
+#. Under the ``parameters:`` section replace the ``private_net_id``, ``private_subnet_id`` and ``public_net_id`` default values with ones you copied.
+#. Under the ``parameters:`` section replace the ``image_id`` with defined name  while importing image in Glance.
+#. Under the ``parameters:`` section replace the ``key_name`` with defined Key pair name.
 #. Log in to KQueen web UI.
 #. From the ``Create Provisioner`` page, select ``Openstack Engine``.
 #. Fill the form with the User Name, Password, Project/Tenant Name and Authentication URL

--- a/kqueen/engines/openstack.py
+++ b/kqueen/engines/openstack.py
@@ -46,7 +46,7 @@ class OpenstackEngine(BaseEngine):
                     'required': True
                 }
             },
-            'os_tenant_name': {
+            'os_project_name': {
                 'type': 'text',
                 'label': 'Project/Tenant Name',
                 'order': 2,
@@ -54,10 +54,26 @@ class OpenstackEngine(BaseEngine):
                     'required': True
                 }
             },
+            'os_user_domain_name': {
+                'type': 'text',
+                'label': 'User Domain Name',
+                'order': 3,
+                'validators': {
+                    'required': True
+                }
+            },
+            'os_project_domain_name': {
+                'type': 'text',
+                'label': 'Project Domain Name',
+                'order': 4,
+                'validators': {
+                    'required': True
+                }
+            },
             'os_auth_url': {
                 'type': 'text',
                 'label': 'Authentication URL (keystone)',
-                'order': 3,
+                'order': 5,
                 'validators': {
                     'required': True
                 }
@@ -65,7 +81,7 @@ class OpenstackEngine(BaseEngine):
             'os_heat_k8s_template': {
                 'type': 'yaml_file',
                 'label': 'Heat template to use for building k8s clusters',
-                'order': 4,
+                'order': 6,
                 'validators': {
                     'required': True,
                     'yamlfile': []
@@ -95,22 +111,29 @@ class OpenstackEngine(BaseEngine):
         # Client initialization
         self.os_username = kwargs.get('os_username', '')
         self.os_password = kwargs.get('os_password', '')
-        self.os_tenant_name = kwargs.get('os_tenant_name', '')
+        self.os_project_name = kwargs.get('os_project_name', '')
         self.os_auth_url = kwargs.get('os_auth_url', '')
+        self.os_user_domain_name = kwargs.get('os_user_domain_name', 'default')
+        self.os_project_domain_name = kwargs.get('os_project_domain_name', 'default')
         self.os_heat_k8s_template = kwargs.get('os_heat_k8s_template', '')
+        self.cluster_id = 'a' + self.cluster.id.replace('-', '')
         self.client = self._get_client()
         # Cache settings
         self.cache_timeout = 5 * 60
+        if not isinstance(cluster.metadata, dict):
+            self.cluster.metadata = {}
 
     def _get_client(self):
         """
         Initialize Openstack Heat client
         """
-        loader = loading.get_plugin_loader(self.os_password)
+        loader = loading.get_plugin_loader('password')
         auth = loader.load_from_options(auth_url=self.os_auth_url,
                                         username=self.os_username,
                                         password=self.os_password,
-                                        project_name=self.os_project_name)
+                                        project_name=self.os_project_name,
+                                        project_domain_name=self.os_project_domain_name,
+                                        user_domain_name=self.os_user_domain_name)
         sess = session.Session(auth=auth)
         client = hclient.Client('1', session=sess)
         return client
@@ -120,8 +143,11 @@ class OpenstackEngine(BaseEngine):
         Implementation of :func:`~kqueen.engines.base.BaseEngine.provision`
         """
         try:
-            response = self.client.stacks.create(files={}, disable_rollback=True, name=self.name, template=self.os_heat_k8s_template)
-            self.cluster.id = response.id
+            response = self.client.stacks.create(files={},
+                                                 disable_rollback=True,
+                                                 stack_name=self.cluster_id,
+                                                 template=self.os_heat_k8s_template)
+            self.cluster.metadata['heat_cluster_id'] = response['stack']['id']
             self.cluster.save()
             # TODO: check if provisioning response is healthy
         except Exception as e:
@@ -139,7 +165,7 @@ class OpenstackEngine(BaseEngine):
         if result:
             return result, error
         try:
-            self.client.stacks.delete(self.cluster.id)
+            self.client.stacks.delete(self.cluster.metadata['heat_cluster_id'])
             # TODO: check if deprovisioning response is healthy
         except Exception as e:
             msg = 'Deleting cluster {} failed with the following reason:'.format(self.cluster.id)
@@ -167,12 +193,17 @@ class OpenstackEngine(BaseEngine):
         Implementation of :func:`~kqueen.engines.base.BaseEngine.get_kubeconfig`
         """
         if not self.cluster.kubeconfig:
-            cluster = self.client.stacks.get(self.cluster.id)
+            cluster = self.client.stacks.get(self.cluster.metadata['heat_cluster_id'])
             kubeconfig = {}
             if cluster.stack_status != "CREATE_COMPLETE":
                 return self.cluster.kubeconfig
-            response = urlopen(self.client.stacks.output_show(self.cluster.id, "kubeconfig"))
-            kubeconfig = response.read()
+
+            response = self.client.stacks.output_show(self.cluster.metadata['heat_cluster_id'], "kubeconfig")
+            conf = urlopen(response['output']['output_value'])
+            kubeconfig = conf.read()
+            # TODO check that k8s config is valid, otherwise recompile it like in GKE engine code
+            k8s_yml = yaml.load(kubeconfig)
+            logger.debug('current kubeconfig: {}'.format(k8s_yml))
             self.cluster.kubeconfig = yaml.load(kubeconfig)
             self.cluster.save()
         return self.cluster.kubeconfig
@@ -182,7 +213,7 @@ class OpenstackEngine(BaseEngine):
         Implementation of :func:`~kqueen.engines.base.BaseEngine.cluster_get`
         """
         try:
-            response = self.client.stacks.get(self.cluster.id)
+            response = self.client.stacks.get(self.cluster.metadata['heat_cluster_id'])
         except Exception as e:
             msg = 'Fetching data from backend for cluster {} failed with the following reason:'.format(self.cluster.id)
             logger.exception(msg)
@@ -205,20 +236,29 @@ class OpenstackEngine(BaseEngine):
 
     @classmethod
     def engine_status(cls, **kwargs):
+        os_username = kwargs.get('os_username', '')
+        os_password = kwargs.get('os_password', '')
+        os_project_name = kwargs.get('os_project_name', '')
+        os_auth_url = kwargs.get('os_auth_url', '')
+        os_user_domain_name = kwargs.get('os_user_domain_name', 'default')
+        os_project_domain_name = kwargs.get('os_project_domain_name', 'default')
         try:
-            loader = loading.get_plugin_loader(cls.os_password)
-            auth = loader.load_from_options(auth_url=cls.os_auth_url,
-                                            username=cls.os_username,
-                                            password=cls.os_password,
-                                            project_name=cls.os_project_name)
+            loader = loading.get_plugin_loader('password')
+            auth = loader.load_from_options(auth_url=os_auth_url,
+                                            username=os_username,
+                                            password=os_password,
+                                            project_name=os_project_name,
+                                            project_domain_name=os_project_domain_name,
+                                            user_domain_name=os_user_domain_name)
             sess = session.Session(auth=auth)
         except Exception:
             logger.exception('{} Openstack Provisioner validation failed.'.format(cls.name))
-            return config.get('PROVISIONER_UNKNOWN_STATE')
+            return config.get('PROVISIONER_ERROR_STATE')
         client = hclient.Client('1', session=sess)
         try:
             list(client.stacks.list())
         except Exception:
             logger.exception('{} Openstack Provisioner validation failed.'.format(cls.name))
             return config.get('PROVISIONER_UNKNOWN_STATE')
+        logger.debug('{} Openstack Provisioner validation passed successfully.'.format(cls.name))
         return config.get('PROVISIONER_OK_STATE')


### PR DESCRIPTION
- useful fields for keystone auth added
- cls calls in engine_status switched to kwargs coz Class doesnot have useful attrs
-  save specific heat_id in metadata to avoid cluster-duplicationg in etcd

Test-case
OS test-env:
my-own-ldap-creds

Kube-docker-salt
7056e316b1294944a51c055fc792dfaf

ldap

https://horizon-eu.ssl.mirantis.net:5000/v3
---------------------------------
template:

https://github.com/Mirantis/kqueen/prod/openstack/heat-templates/kubernetes-cluster.yaml
-----------------------------------
Current issues:
stucks on ``CREATE_IN_PROGRESS`` state

*FOR DEMO ONLY*
*DEPENDS-ON:* https://github.com/Mirantis/kqueen/pull/296