### PR TITLE
Make organization namespace unique

### DIFF
--- a/kqueen/blueprints/api/test_crud.py
+++ b/kqueen/blueprints/api/test_crud.py
@@ -61,7 +61,8 @@ class BaseTestCRUD:
         self.test_object = self.get_object()
         self.obj = self.test_object.obj
         self.obj.save()
-        self.test_user = UserFixture()
+        namespace = getattr(self.obj, 'namespace', None) or getattr(getattr(self.obj, 'owner', None), 'namespace', None)
+        self.test_user = UserFixture(namespace)
         self.test_auth_header = AuthHeader(self.test_user)
         self.auth_header = self.test_auth_header.get(client)
         self.namespace = self.auth_header['X-Test-Namespace']
@@ -111,7 +112,6 @@ class BaseTestCRUD:
         assert response.status_code == 500
 
     def test_crud_get(self):
-        self.obj.save()
 
         response = self.client.get(
             self.urls['get'],
@@ -242,19 +242,7 @@ class BaseTestCRUD:
         for u in [user1, user2]:
             data = self.get_create_data()
 
-            # TODO: fix this
-            # Dirty hack to make testing data namespaced.
-            organization_data = {
-                'name': 'Test organization',
-                'namespace': 'testorg',
-            }
-            response = self.client.post(
-                url_for('api.organization_create'),
-                data=json.dumps(organization_data),
-                headers=u.auth_header,
-                content_type='application/json',
-            )
-            organization_ref = 'Organization:{}'.format(response.json['id'])
+            organization_ref = 'Organization:{}'.format(u.obj.organization.id)
             profile = faker.Faker().simple_profile()
             owner_data = {
                 'username': profile['username'],

--- a/kqueen/blueprints/api/test_helpers.py
+++ b/kqueen/blueprints/api/test_helpers.py
@@ -6,7 +6,6 @@ from kqueen.conftest import ClusterFixture
 import pytest
 
 
-@pytest.mark.usefixtures('user')
 class TestGetObject:
     def setup(self):
         self.test_cluster = ClusterFixture()
@@ -16,10 +15,10 @@ class TestGetObject:
     def teardown(self):
         self.test_cluster.destroy()
 
-    def test_get_objects(self, user):
+    def test_get_objects(self):
 
         obj = get_object(self.cluster.__class__,
-                         self.cluster.id, user)
+                         self.cluster.id, self.cluster.owner)
 
         assert obj.get_dict(True) == obj.get_dict(True)
 

--- a/kqueen/blueprints/api/test_organization.py
+++ b/kqueen/blueprints/api/test_organization.py
@@ -36,6 +36,13 @@ class TestOrganizationCRUD(BaseTestCRUD):
             assert response.status_code == 500
             assert isinstance(remaining, list) and remaining
 
+    def get_create_data(self):
+        data = self.obj.get_dict(expand=True)
+        data.update(self.get_edit_data())
+        data['id'] = None
+
+        return data
+
     def test_policy(self):
         url = url_for('api.organization_policy', pk=self.obj.id)
 

--- a/kqueen/blueprints/metrics/test_helpers.py
+++ b/kqueen/blueprints/metrics/test_helpers.py
@@ -1,3 +1,4 @@
+from kqueen.conftest import UserFixture
 from .helpers import MetricUpdater
 from prometheus_client import generate_latest
 
@@ -6,13 +7,14 @@ import pytest
 
 class TestMetricUpdates:
     @pytest.fixture(scope='class')
-    def latest(self, user):
-        user.save()
-
+    def latest(self):
+        user = UserFixture(namespace='demoorg')
         m = MetricUpdater()
         m.update_metrics()
 
-        return generate_latest().decode('utf-8')
+        result = generate_latest().decode('utf-8')
+        user.destroy()
+        return result
 
     @pytest.mark.parametrize('metric', [
         ('users_by_namespace{namespace="demoorg"}'),
@@ -20,7 +22,7 @@ class TestMetricUpdates:
         ('users_active'),
         ('organization_count'),
     ])
-    def test_metrics_exist(user, latest, metric):
+    def test_metrics_exist(self, latest, metric):
 
         req = "{metric} ".format(metric=metric)
 

--- a/kqueen/conftest.py
+++ b/kqueen/conftest.py
@@ -11,11 +11,12 @@ import etcd
 import faker
 import json
 import pytest
+import random
+import string
 import uuid
 import yaml
 
 config = current_config()
-fake = faker.Faker()
 fake = faker.Faker()
 current_app = None
 
@@ -79,9 +80,9 @@ class ProvisionerFixture:
 
 
 class UserFixture:
-    def __init__(self):
+    def __init__(self, namespace=None):
         profile = fake.simple_profile()
-        self.test_org = OrganizationFixture()
+        self.test_org = OrganizationFixture(namespace)
         user = User.create(
             None,
             username=profile['username'],
@@ -90,7 +91,7 @@ class UserFixture:
             role='superadmin',
             active=True
         )
-        user.save()
+        user.save(validate=False)
         self.obj = user
 
     def destroy(self):
@@ -103,14 +104,17 @@ class UserFixture:
 
 
 class OrganizationFixture:
-    def __init__(self):
+    def __init__(self, name=None):
         """Prepare organization object."""
+        if not name:
+            name = ''.join(random.choice(string.ascii_letters) for _ in range(8))
         organization = Organization(
             None,
-            name='DemoOrg',
-            namespace='demoorg',
+            name=name,
+            namespace=name
         )
-        organization.save()
+        organization.save(validate=False)
+
         self.obj = organization
 
     def destroy(self):

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -397,7 +397,7 @@ class Organization(Model, metaclass=ModelMeta):
 
     id = IdField(required=True)
     name = StringField(required=True)
-    namespace = StringField(required=True)
+    namespace = StringField(required=True, unique=True)
     policy = JSONField()
     created_at = DatetimeField(default=datetime.utcnow)
 


### PR DESCRIPTION
* Organization namespace corresponds to namespace in k8s,
  so it's not allowed to have idential names.
* Fix corresponding tests, before tests create several organization
  with same namespace