### PR TITLE
Improve azure provisioner: install specific packages, update field names and fix cluster resize

### DIFF
--- a/kqueen/blueprints/api/generic_views.py
+++ b/kqueen/blueprints/api/generic_views.py
@@ -124,8 +124,9 @@ class GetView(GenericView):
     methods = ['GET']
     action = 'get'
 
-    def get_content(self, *args, **kwargs):
-        self.obj = self.hide_secure_data(self.obj)
+    def get_content(self, *args, hide_secure_data=True, **kwargs):
+        if hide_secure_data:
+            self.obj = self.hide_secure_data(self.obj)
         return self.obj
 
 

--- a/kqueen/blueprints/api/test_cluster.py
+++ b/kqueen/blueprints/api/test_cluster.py
@@ -76,7 +76,7 @@ class TestClusterCRUD(BaseTestCRUD):
             self.namespace,
             self.obj.id
         )
-        obj.get_state()
+        obj.update_state()
 
         assert isinstance(data, list)
         assert len(data) == len(self.obj.__class__.list(
@@ -280,7 +280,7 @@ class TestClusterCRUD(BaseTestCRUD):
 
         assert response.status_code == code
 
-    def test_cluster_list_run_get_state(self, monkeypatch):
+    def test_cluster_list_run_update_state(self, monkeypatch):
         clusters_to_remove = []
         for _ in range(10):
             test_cluster = ClusterFixture()
@@ -288,13 +288,13 @@ class TestClusterCRUD(BaseTestCRUD):
             c = test_cluster.obj
             c.save()
 
-        def fake_get_state(self):
+        def fake_update_state(self):
             self.metadata = {'executed': True}
             self.save()
 
             return config.get('CLUSTER_UNKNOWN_STATE')
 
-        monkeypatch.setattr(self.obj.__class__, 'get_state', fake_get_state)
+        monkeypatch.setattr(self.obj.__class__, 'update_state', fake_update_state)
 
         response = self.client.get(
             url_for('api.cluster_list'),
@@ -306,8 +306,8 @@ class TestClusterCRUD(BaseTestCRUD):
 
         obj = self.obj.__class__.load(self.namespace, self.obj.id)
 
-        assert obj.metadata, 'get_state wasn\'t executed for cluster {}'.format(obj)
-        assert obj.metadata['executed'], 'get_state wasn\'t executed'
+        assert obj.metadata, 'update_state wasn\'t executed for cluster {}'.format(obj)
+        assert obj.metadata['executed'], 'update_state wasn\'t executed'
 
         for c in clusters_to_remove:
             c.destroy()

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -76,7 +76,7 @@ class ListClusters(ListView):
         futures = [
             loop.run_in_executor(
                 None,
-                cluster.get_state
+                cluster.update_state
             )
             for cluster in clusters
         ]
@@ -102,7 +102,7 @@ class ListClusters(ListView):
                 logger.exception('Asyncio loop is NOT available, fallback to simple looping: ')
 
                 for c in clusters:
-                    c.get_state()
+                    c.update_state()
                 self.obj = clusters
 
         return super().get_content(self, *args, **kwargs)
@@ -162,7 +162,7 @@ class GetCluster(GetView):
         self.set_object(*args, **kwargs)
         self.check_authorization()
         cluster = self.get_content(*args, hide_secure_data=False, **kwargs)
-        cluster.get_state()
+        cluster.update_state()
         cluster = self.hide_secure_data(self.obj)
         return jsonify(cluster)
 
@@ -217,7 +217,7 @@ def cluster_progress(pk):
         progress = {
             'response': 501,
             'progress': 0,
-            'result': obj.get_state()
+            'result': obj.update_state()
         }
     except Exception:
         progress = {

--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -161,9 +161,9 @@ class GetCluster(GetView):
         self.check_authentication()
         self.set_object(*args, **kwargs)
         self.check_authorization()
-        cluster = self.get_content(*args, **kwargs)
+        cluster = self.get_content(*args, hide_secure_data=False, **kwargs)
         cluster.get_state()
-
+        cluster = self.hide_secure_data(self.obj)
         return jsonify(cluster)
 
 

--- a/kqueen/engines/aks.py
+++ b/kqueen/engines/aks.py
@@ -34,7 +34,7 @@ class AksEngine(BaseEngine):
         'provisioner': {
             'client_id': {
                 'type': 'text',
-                'label': 'Client ID',
+                'label': 'Application ID',
                 'order': 0,
                 'validators': {
                     'required': True,
@@ -51,7 +51,7 @@ class AksEngine(BaseEngine):
             },
             'tenant': {
                 'type': 'text',
-                'label': 'Tenant ID',
+                'label': 'Directory ID',
                 'order': 2,
                 'validators': {
                     'required': True,

--- a/kqueen/models.py
+++ b/kqueen/models.py
@@ -37,7 +37,7 @@ class Cluster(Model, metaclass=ModelMeta):
     created_at = DatetimeField(default=datetime.utcnow)
     owner = RelationField(required=True, remote_class_name='User')
 
-    def get_state(self):
+    def update_state(self):
         try:
             remote_cluster = self.engine.cluster_get()
         except Exception as e:

--- a/kqueen/tests/test_models.py
+++ b/kqueen/tests/test_models.py
@@ -229,7 +229,7 @@ class TestClusterState:
         self.cluster = cluster
 
     def test_stale_cluster(self):
-        cluster_state = self.cluster.get_state()
-        print(self.cluster.get_state())
+        cluster_state = self.cluster.update_state()
+        print(self.cluster.update_state())
 
         assert cluster_state == config.get('CLUSTER_ERROR_STATE')

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,9 @@ setup(
         'google-api-python-client==1.6.4',
         'google-auth==1.2.1',
         'google-auth-httplib2==0.0.3',
-        'azure==2.0.0',
-        'azure-mgmt-containerservice==3.0.1',
+        'azure-common==1.1.9',
+        'azure-mgmt-containerservice==3.0.0',
+        'msrestazure==0.4.25',
         'urllib3==1.22'
     ],
     setup_requires=[


### PR DESCRIPTION
Often azure brakes package dependencies and our CI became broken.
Install only that azure packages, that we are using.