### PR TITLE
Consider some additional fields while sorting

### DIFF
--- a/kqueen/blueprints/api/views.py
+++ b/kqueen/blueprints/api/views.py
@@ -73,12 +73,12 @@ class ListClusters(ListView):
     object_class = Cluster
 
     supported_sort_fields = {
-        'name': lambda x: x.name,
-        'provisioner': lambda x: x.provisioner.name,
-        'created_at': lambda x: x.created_at,
-        'created': lambda x: x.created_at,
-        'status': lambda x: x.state,
-        'state': lambda x: x.state,
+        'name': lambda x: (x.name, x.created_at, x.id),
+        'provisioner': lambda x: (x.provisioner.name, x.name, x.id),
+        'created_at': lambda x: (x.created_at, x.name, x.id),
+        'created': lambda x: (x.created_at, x.name, x.id),
+        'status': lambda x: (x.state, x.name, x.id),
+        'state': lambda x: (x.state, x.name, x.id),
     }
 
     def filter_objects(self, objects, filters):
@@ -304,12 +304,12 @@ class ListProvisioners(ListView):
     object_class = Provisioner
 
     supported_sort_fields = {
-        'name': lambda x: x.name,
-        'engine': lambda x: x.engine,
-        'created_at': lambda x: x.created_at,
-        'created': lambda x: x.created_at,
-        'status': lambda x: x.state,
-        'state': lambda x: x.state,
+        'name': lambda x: (x.name, x.created_at, x.id),
+        'engine': lambda x: (x.engine, x.name, x.id),
+        'created_at': lambda x: (x.created_at, x.id),
+        'created': lambda x: (x.created_at, x.id),
+        'status': lambda x: (x.state, x.name, x.id),
+        'state': lambda x: (x.state, x.name, x.id),
     }
 
     def filter_objects(self, objects, filters):


### PR DESCRIPTION
If you sort only by one key, then in case of objects with
similar fields order can be randomly changed after page switching.
To avoid this, sort by id was added. Also sorting by name was added
for more readability.