### PR TITLE
Access ip workaround

### DIFF
--- a/kqueen/engines/openstack_kubespray.py
+++ b/kqueen/engines/openstack_kubespray.py
@@ -610,10 +610,7 @@ class OpenStack:
             ipaddress.ip_address(address)
             return address
 
-        mc = self.cluster.metadata["master_count"]
-        if mc % 2 == 0 or mc == 1:
-            raise ValueError("Master node count must be an odd number at least 3 or greater")
-        self.meta["master_count"] = mc
+        self.meta["master_count"] = self.cluster.metadata["master_count"]
         self.meta["slave_count"] = self.cluster.metadata["slave_count"]
 
         self.meta["dns"] = [validate_ip(ip) for ip in

--- a/kqueen/engines/openstack_kubespray.py
+++ b/kqueen/engines/openstack_kubespray.py
@@ -80,7 +80,6 @@ class OpenstackKubesprayEngine(BaseEngine):
                 "help_message": "Must be odd number",
                 "validators": {
                     "required": True,
-                    "min": 3,
                     "parity": "odd",
                 },
             },


### PR DESCRIPTION
In some OpenStack deployments VM can't reach itself by floating ip. Some kubespray checks are not successful and deployment fails.

Solved by adding floating ip to loopback interface.

Also few minor fixes.